### PR TITLE
Depend on mockito-core only.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ dependencies {
     compile 'com.sksamuel.koors:koors:0.90.0'
     compile 'org.jetbrains.kotlin:kotlin-stdlib:1.0.3'
     compile 'org.jetbrains.kotlin:kotlin-reflect:1.0.3'
-    compile 'org.mockito:mockito-all:1.10.19'
+    compile 'org.mockito:mockito-core:1.10.19'
 }
 
 uploadArchives {


### PR DESCRIPTION
`kotlintest` only uses stuff from `mockito-core`. Otherwise e.g.
when you use `maven-enforcer-plugin` and define a rule which
forbids duplicate classes there is a clash because `mockito-all`
defines some matchers itself.