### PR TITLE
Allow to write tests directly in the class constructors.

### DIFF
--- a/src/main/kotlin/io/kotlintest/specs/BehaviorSpec.kt
+++ b/src/main/kotlin/io/kotlintest/specs/BehaviorSpec.kt
@@ -5,7 +5,8 @@ import io.kotlintest.TestCase
 import io.kotlintest.TestSuite
 import java.util.*
 
-abstract class BehaviorSpec : TestBase() {
+abstract class BehaviorSpec(body: BehaviorSpec.() -> Unit = {}) : TestBase() {
+  init { body(this) }
 
   var current = root
 

--- a/src/main/kotlin/io/kotlintest/specs/FeatureSpec.kt
+++ b/src/main/kotlin/io/kotlintest/specs/FeatureSpec.kt
@@ -5,7 +5,8 @@ import io.kotlintest.TestCase
 import io.kotlintest.TestSuite
 import java.util.*
 
-abstract class FeatureSpec : TestBase() {
+abstract class FeatureSpec(body: FeatureSpec.() -> Unit = {}) : TestBase() {
+  init { body(this) }
 
   var current = root
 

--- a/src/main/kotlin/io/kotlintest/specs/FlatSpec.kt
+++ b/src/main/kotlin/io/kotlintest/specs/FlatSpec.kt
@@ -4,7 +4,8 @@ import io.kotlintest.*
 import java.util.*
 import java.util.concurrent.TimeUnit
 
-abstract class FlatSpec : TestBase() {
+abstract class FlatSpec(body: FlatSpec.() -> Unit = {}) : TestBase() {
+  init { body(this) }
 
   protected val suites: MutableMap<String, TestSuite> = HashMap()
 

--- a/src/main/kotlin/io/kotlintest/specs/FreeSpec.kt
+++ b/src/main/kotlin/io/kotlintest/specs/FreeSpec.kt
@@ -4,7 +4,8 @@ import io.kotlintest.TestBase
 import io.kotlintest.TestCase
 import io.kotlintest.TestSuite
 
-abstract class FreeSpec : TestBase() {
+abstract class FreeSpec(body: FreeSpec.() -> Unit = {}) : TestBase() {
+  init { body(this) }
 
   var current = root
 

--- a/src/main/kotlin/io/kotlintest/specs/FunSpec.kt
+++ b/src/main/kotlin/io/kotlintest/specs/FunSpec.kt
@@ -3,7 +3,8 @@ package io.kotlintest.specs
 import io.kotlintest.TestBase
 import io.kotlintest.TestCase
 
-abstract class FunSpec : TestBase() {
+abstract class FunSpec(body: FunSpec.() -> Unit = {}) : TestBase() {
+  init { body(this) }
 
   fun test(name: String, test: () -> Unit): TestCase {
     val tc = TestCase(suite = root, name = name, test = test, config = defaultTestCaseConfig)

--- a/src/main/kotlin/io/kotlintest/specs/ShouldSpec.kt
+++ b/src/main/kotlin/io/kotlintest/specs/ShouldSpec.kt
@@ -4,7 +4,8 @@ import io.kotlintest.TestBase
 import io.kotlintest.TestCase
 import io.kotlintest.TestSuite
 
-abstract class ShouldSpec : TestBase() {
+abstract class ShouldSpec(body: ShouldSpec.() -> Unit = {}) : TestBase() {
+  init { body(this) }
 
   var current = root
 

--- a/src/main/kotlin/io/kotlintest/specs/StringSpec.kt
+++ b/src/main/kotlin/io/kotlintest/specs/StringSpec.kt
@@ -3,7 +3,8 @@ package io.kotlintest.specs
 import io.kotlintest.TestBase
 import io.kotlintest.TestCase
 
-abstract class StringSpec : TestBase() {
+abstract class StringSpec(body: StringSpec.() -> Unit = {}) : TestBase() {
+  init { body(this) }
 
   operator fun String.invoke(test: () -> Unit): TestCase {
     val tc = TestCase(suite = root, name = this, test = test, config = defaultTestCaseConfig)

--- a/src/main/kotlin/io/kotlintest/specs/WordSpec.kt
+++ b/src/main/kotlin/io/kotlintest/specs/WordSpec.kt
@@ -5,7 +5,8 @@ import io.kotlintest.TestCase
 import io.kotlintest.TestSuite
 import java.util.*
 
-abstract class WordSpec : TestBase() {
+abstract class WordSpec(body: WordSpec.() -> Unit = {}) : TestBase() {
+  init { body(this) }
 
   var current = root
 

--- a/src/test/kotlin/io/kotlintest/specs/StringSpecTest.kt
+++ b/src/test/kotlin/io/kotlintest/specs/StringSpecTest.kt
@@ -14,3 +14,11 @@ class StringSpecTest : StringSpec() {
     }.config(invocations = 5)
   }
 }
+
+class StringSpecConstructorTest : StringSpec({
+
+  "strings.size should return size of string" {
+    "hello".length shouldBe 5
+    "hello" should haveLength(5)
+  }
+})


### PR DESCRIPTION
It allows to write tests into the class constructor. Writing tests in the `init()` block is still supported.

~~~kotlin
class StringSpecExample : StringSpec({

    "strings.size should return size of string" {
        "hello" should haveLength(5)
    }
})
~~~
