### PR TITLE
remove redundant reference to object instance when calling ext. function

### DIFF
--- a/src/main/kotlin/io/kotlintest/specs/BehaviorSpec.kt
+++ b/src/main/kotlin/io/kotlintest/specs/BehaviorSpec.kt
@@ -6,7 +6,7 @@ import io.kotlintest.TestSuite
 import java.util.*
 
 abstract class BehaviorSpec(body: BehaviorSpec.() -> Unit = {}) : TestBase() {
-  init { body(this) }
+  init { body() }
 
   var current = root
 

--- a/src/main/kotlin/io/kotlintest/specs/FeatureSpec.kt
+++ b/src/main/kotlin/io/kotlintest/specs/FeatureSpec.kt
@@ -6,7 +6,7 @@ import io.kotlintest.TestSuite
 import java.util.*
 
 abstract class FeatureSpec(body: FeatureSpec.() -> Unit = {}) : TestBase() {
-  init { body(this) }
+  init { body() }
 
   var current = root
 

--- a/src/main/kotlin/io/kotlintest/specs/FreeSpec.kt
+++ b/src/main/kotlin/io/kotlintest/specs/FreeSpec.kt
@@ -5,7 +5,7 @@ import io.kotlintest.TestCase
 import io.kotlintest.TestSuite
 
 abstract class FreeSpec(body: FreeSpec.() -> Unit = {}) : TestBase() {
-  init { body(this) }
+  init { body() }
 
   var current = root
 

--- a/src/main/kotlin/io/kotlintest/specs/FunSpec.kt
+++ b/src/main/kotlin/io/kotlintest/specs/FunSpec.kt
@@ -4,7 +4,7 @@ import io.kotlintest.TestBase
 import io.kotlintest.TestCase
 
 abstract class FunSpec(body: FunSpec.() -> Unit = {}) : TestBase() {
-  init { body(this) }
+  init { body() }
 
   fun test(name: String, test: () -> Unit): TestCase {
     val tc = TestCase(suite = root, name = name, test = test, config = defaultTestCaseConfig)

--- a/src/main/kotlin/io/kotlintest/specs/ShouldSpec.kt
+++ b/src/main/kotlin/io/kotlintest/specs/ShouldSpec.kt
@@ -5,7 +5,7 @@ import io.kotlintest.TestCase
 import io.kotlintest.TestSuite
 
 abstract class ShouldSpec(body: ShouldSpec.() -> Unit = {}) : TestBase() {
-  init { body(this) }
+  init { body() }
 
   var current = root
 

--- a/src/main/kotlin/io/kotlintest/specs/StringSpec.kt
+++ b/src/main/kotlin/io/kotlintest/specs/StringSpec.kt
@@ -4,7 +4,7 @@ import io.kotlintest.TestBase
 import io.kotlintest.TestCase
 
 abstract class StringSpec(body: StringSpec.() -> Unit = {}) : TestBase() {
-  init { body(this) }
+  init { body() }
 
   operator fun String.invoke(test: () -> Unit): TestCase {
     val tc = TestCase(suite = root, name = this, test = test, config = defaultTestCaseConfig)

--- a/src/main/kotlin/io/kotlintest/specs/WordSpec.kt
+++ b/src/main/kotlin/io/kotlintest/specs/WordSpec.kt
@@ -6,7 +6,7 @@ import io.kotlintest.TestSuite
 import java.util.*
 
 abstract class WordSpec(body: WordSpec.() -> Unit = {}) : TestBase() {
-  init { body(this) }
+  init { body() }
 
   var current = root
 


### PR DESCRIPTION
Hey, loving your work on this lib. This is just a minor tweak which I consider to be more idiomatic Kotlin: passing the object instance as a parameter to the function is a bit util-function like, which is helpful when calling it from Java, but from Kotlin we can embrace the fact that it's an extension function to the full extent, and treat it as if it were a member function, hence we can omit `this`.

However, as this is just a style issue open to interpretation I understand if you'd rather keep it as it is. Hope this helps.