### PR TITLE
Feature/#77 extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,9 +467,9 @@ val myTestCaseInterceptor: (TestCaseContext, () -> Unit) -> Unit = { context, te
 }
 ```
 
-### Executing Code Before and After a Whole Project
+###  Executing Code Before and After a Whole Project
 
-To run test before the very first test case or after the very last test case of you your project you can define a ProjectConfig singleton object derived from `ProjectConfig` somewhere in your test folder (it will be found per reflection, so the location is not important as long as the object is on the class path).
+To run some logic before the very first test case or after the very last test case of you your project you can define a ProjectConfig singleton object derived from `ProjectConfig` somewhere in your test folder (preferably in the top-level test folder, but it will be found anywhere on the class path).
 
 Override `beforeAll` and/or `afterAll`, to provide logic to be run before or after all tests of the project.
 
@@ -512,7 +512,15 @@ object DemoConfig : ProjectConfig() {
 }
 ```
 
-An implementation would look like this:
+The `beforeAll` methods of the extensions are executed in the order of extensions (from left to right). The `afterAll` methods are executed in reversed order (from right to left). If you had two extensions `listOf(A, B)` the order of execution would be:
+
+* `A.beforeAll`
+  * `B.beforeAll`
+    * test execution
+  * `B.afterAll`
+* `A.afterAll`.
+
+A `ProjectExtension` implementation would look like this:
 
 ```kotlin
 object TestExtension : ProjectExtension {
@@ -523,23 +531,6 @@ object TestExtension : ProjectExtension {
   override fun afterAll() {
     println("after all extension")
   }
-}
-```
-
-Before and After All
---------------------
-
-If you need to run a setup/tear down function before and after all the tests have run, then simply override the `beforeAll` and `afterAll` methods in your test class, eg:
-
-```kotlin
-override fun beforeAll() {
-  println("Setting up my tests")
-}
-```
-
-```kotlin
-override fun afterAll() {
-  println("Cleaning up after my tests")
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -364,7 +364,7 @@ There are several points where you can hook in the test execution.
   * ProjectConfig.afterAll
 * ProjectConfig.extensions afterAll
 
-The general philoshopy is here that the closer an interceptor is to a test case, the closer it is to the test case in the execution order.
+The general philoshopy here, is that the closer an interceptor is to a test case, the closer it is to the test case in the execution order.
 
 The execution order within an interceptor collection (`ProjectConfig.extentions`, `Spec.interceptors`) is from left to right.
 

--- a/README.md
+++ b/README.md
@@ -438,7 +438,7 @@ Interceptors are just functions and can be reused between specs or even between 
 ```kotlin
 "should do it correctly" {
   ...
-}.config(interceptors = listof(myTestCaseInterceptor))
+}.config(interceptors = listOf(myTestCaseInterceptor))
 ```
 
 An interceptor would look like this:

--- a/README.md
+++ b/README.md
@@ -39,12 +39,14 @@ Testing Styles
 You can choose a testing style by extending StringSpec, WordSpec, FunSpec, ShouldSpec, FeatureSpec, BehaviorSpec or FreeSpec in your test class, and writing your tests either inside an `init {}` block or inside a lambda parameter in the class constructor.
 
 ```kotlin
+// test cases in init block
 class MyTests : StringSpec() {
   init {
     // tests here
   }
 }
 
+// test cases in lambda expression
 class MyTests : StringSpec({
   // tests here
 })

--- a/README.md
+++ b/README.md
@@ -362,7 +362,9 @@ There are several points where you can hook in the test execution.
   * ProjectConfig.afterAll
 * ProjectConfig.extensions afterAll
 
-The general philoshopy is here that the closer an interceptor is to a test case, the closer it is to the test case in the execution order. 
+The general philoshopy is here that the closer an interceptor is to a test case, the closer it is to the test case in the execution order.
+
+The execution order within an interceptor collection (`ProjectConfig.extentions`, `Spec.interceptors`) is from left to right.
 
 ### Intercepting a Test Case
 

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ dependencies {
     compile 'org.jetbrains.kotlin:kotlin-stdlib:1.0.3'
     compile 'org.jetbrains.kotlin:kotlin-reflect:1.0.3'
     compile 'org.mockito:mockito-core:1.10.19'
+    compile 'org.reflections:reflections:0.9.10'
 }
 
 uploadArchives {

--- a/src/main/kotlin/io/kotlintest/InvalidConfigException.kt
+++ b/src/main/kotlin/io/kotlintest/InvalidConfigException.kt
@@ -1,0 +1,6 @@
+package io.kotlintest
+
+/**
+ * Signals an invalid configuration
+ */
+class InvalidConfigException(message: String) : Exception(message)

--- a/src/main/kotlin/io/kotlintest/InvalidConfigException.kt
+++ b/src/main/kotlin/io/kotlintest/InvalidConfigException.kt
@@ -3,4 +3,4 @@ package io.kotlintest
 /**
  * Signals an invalid configuration
  */
-class InvalidConfigException(message: String) : Exception(message)
+class InvalidConfigException(message: String) : RuntimeException(message)

--- a/src/main/kotlin/io/kotlintest/Project.kt
+++ b/src/main/kotlin/io/kotlintest/Project.kt
@@ -31,7 +31,7 @@ object Project {
     synchronized(executedAfter) {
       if (!executedAfter) {
         projectConfig?.afterAll()
-        projectConfig?.extensions?.forEach { extension -> extension.afterAll() }
+        projectConfig?.extensions?.reversed()?.forEach { extension -> extension.afterAll() }
         executedAfter = true
       }
     }

--- a/src/main/kotlin/io/kotlintest/Project.kt
+++ b/src/main/kotlin/io/kotlintest/Project.kt
@@ -11,7 +11,7 @@ object Project {
   init {
     val configClasses = Reflections("io.kotlintest").getSubTypesOf(ProjectConfig::class.java)
     if (configClasses.size > 1)  {
-      val configClassNames = configClasses.map { config -> config.typeName }
+      val configClassNames = configClasses.map { config -> config.simpleName }
       throw InvalidConfigException("Duplicate GlobalConfig found: $configClassNames")
     }
     projectConfig = configClasses.firstOrNull()?.kotlin?.objectInstance

--- a/src/main/kotlin/io/kotlintest/Project.kt
+++ b/src/main/kotlin/io/kotlintest/Project.kt
@@ -20,20 +20,19 @@ object Project {
 
   fun beforeAll() {
     synchronized(executedBefore) {
-      if (!executedBefore.get()) {
+      if (executedBefore.compareAndSet(false, true)) {
         projectConfig?.extensions?.forEach { extension -> extension.beforeAll() }
         projectConfig?.beforeAll()
-        executedBefore.compareAndSet(false, true)
+
       }
     }
   }
 
   fun afterAll() {
     synchronized(executedAfter) {
-      if (!executedAfter.get()) {
+      if (executedAfter.compareAndSet(false, true)) {
         projectConfig?.afterAll()
         projectConfig?.extensions?.reversed()?.forEach { extension -> extension.afterAll() }
-        executedAfter.compareAndSet(false, true)
       }
     }
   }

--- a/src/main/kotlin/io/kotlintest/Project.kt
+++ b/src/main/kotlin/io/kotlintest/Project.kt
@@ -1,28 +1,6 @@
 package io.kotlintest
 
-// TODO rename and split file
-
 import org.reflections.Reflections
-
-data class TestCaseContext(
-    val spec: TestBase,
-    val testCase: TestCase)
-
-interface ProjectExtension {
-  fun beforeAll() {}
-  fun afterAll() {}
-}
-
-
-abstract class ProjectConfig {
-
-  open val extensions: List<ProjectExtension> = listOf()
-
-  open fun beforeAll() {}
-
-  open fun afterAll() {}
-}
-
 
 object Project {
 
@@ -59,6 +37,3 @@ object Project {
     }
   }
 }
-
-
-class InvalidConfigException(message: String) : Exception(message)

--- a/src/main/kotlin/io/kotlintest/Project.kt
+++ b/src/main/kotlin/io/kotlintest/Project.kt
@@ -1,12 +1,13 @@
 package io.kotlintest
 
 import org.reflections.Reflections
+import java.util.concurrent.atomic.AtomicBoolean
 
 object Project {
 
   private var projectConfig: ProjectConfig? = null
-  private var executedBefore = false
-  private var executedAfter = false
+  private var executedBefore = AtomicBoolean(false)
+  private var executedAfter = AtomicBoolean(false)
 
   init {
     val configClasses = Reflections("io.kotlintest").getSubTypesOf(ProjectConfig::class.java)
@@ -19,20 +20,20 @@ object Project {
 
   fun beforeAll() {
     synchronized(executedBefore) {
-      if (!executedBefore) {
+      if (!executedBefore.get()) {
         projectConfig?.extensions?.forEach { extension -> extension.beforeAll() }
         projectConfig?.beforeAll()
-        executedBefore = true
+        executedBefore.set(true)
       }
     }
   }
 
   fun afterAll() {
     synchronized(executedAfter) {
-      if (!executedAfter) {
+      if (!executedAfter.get()) {
         projectConfig?.afterAll()
         projectConfig?.extensions?.reversed()?.forEach { extension -> extension.afterAll() }
-        executedAfter = true
+        executedAfter.set(true)
       }
     }
   }

--- a/src/main/kotlin/io/kotlintest/Project.kt
+++ b/src/main/kotlin/io/kotlintest/Project.kt
@@ -6,8 +6,8 @@ import java.util.concurrent.atomic.AtomicBoolean
 object Project {
 
   private var projectConfig: ProjectConfig? = null
-  private var executedBefore = AtomicBoolean(false)
-  private var executedAfter = AtomicBoolean(false)
+  private val executedBefore = AtomicBoolean(false)
+  private val executedAfter = AtomicBoolean(false)
 
   init {
     val configClasses = Reflections("io.kotlintest").getSubTypesOf(ProjectConfig::class.java)
@@ -23,7 +23,7 @@ object Project {
       if (!executedBefore.get()) {
         projectConfig?.extensions?.forEach { extension -> extension.beforeAll() }
         projectConfig?.beforeAll()
-        executedBefore.set(true)
+        executedBefore.compareAndSet(false, true)
       }
     }
   }
@@ -33,7 +33,7 @@ object Project {
       if (!executedAfter.get()) {
         projectConfig?.afterAll()
         projectConfig?.extensions?.reversed()?.forEach { extension -> extension.afterAll() }
-        executedAfter.set(true)
+        executedAfter.compareAndSet(false, true)
       }
     }
   }

--- a/src/main/kotlin/io/kotlintest/ProjectConfig.kt
+++ b/src/main/kotlin/io/kotlintest/ProjectConfig.kt
@@ -8,17 +8,21 @@ package io.kotlintest
 abstract class ProjectConfig {
 
   /**
-   * List of project-wide extensions, executed from left to right.
+   * List of project-wide extensions. The [ProjectExtension.beforeAll] methods of the
+   * [ProjectExtension]s are executed in the order of [ProjectExtension]s from left to right. The
+   * [ProjectExtension.afterAll] methods are executed in reversed order (from right to left).
    */
   open val extensions: List<ProjectExtension> = listOf()
 
   /**
-   * Executed before the first test of the project.
+   * Executed before the first test of the project, but after the [ProjectExtension.beforeAll]
+   * methods of extensions.
    */
   open fun beforeAll() {}
 
   /**
-   * Executed after the last test of the project.
+   * Executed after the last test of the project, but before the [ProjectExtension.afterAll]
+   * methods.
    */
   open fun afterAll() {}
 }

--- a/src/main/kotlin/io/kotlintest/ProjectConfig.kt
+++ b/src/main/kotlin/io/kotlintest/ProjectConfig.kt
@@ -1,0 +1,24 @@
+package io.kotlintest
+
+/**
+ * Project-wide configuration.
+ *
+ * Create an object that is derived from this class and place it in the (top-level) test package.
+ */
+abstract class ProjectConfig {
+
+  /**
+   * List of project-wide extensions, executed from left to right.
+   */
+  open val extensions: List<ProjectExtension> = listOf()
+
+  /**
+   * Executed before the first test of the project.
+   */
+  open fun beforeAll() {}
+
+  /**
+   * Executed after the last test of the project.
+   */
+  open fun afterAll() {}
+}

--- a/src/main/kotlin/io/kotlintest/ProjectExtension.kt
+++ b/src/main/kotlin/io/kotlintest/ProjectExtension.kt
@@ -1,0 +1,17 @@
+package io.kotlintest
+
+/**
+ * Reusable extension to be registered with [ProjectConfig.extensions].
+ */
+interface ProjectExtension {
+
+  /**
+   * Executed before the first test of the project and before [ProjectConfig.beforeAll].
+   */
+  fun beforeAll() {}
+
+  /**
+   * Executed after the last test of the project and after [ProjectConfig.afterAll]
+   */
+  fun afterAll() {}
+}

--- a/src/main/kotlin/io/kotlintest/SpecExtension.kt
+++ b/src/main/kotlin/io/kotlintest/SpecExtension.kt
@@ -3,8 +3,8 @@ package io.kotlintest
 import org.reflections.Reflections
 
 interface TestCaseInterceptor {
-  operator fun invoke(context: TestCaseContext, callable: () -> Unit) {
-    callable()
+  operator fun invoke(context: TestCaseContext, testCase: () -> Unit) {
+    testCase()
   }
 }
 

--- a/src/main/kotlin/io/kotlintest/SpecExtension.kt
+++ b/src/main/kotlin/io/kotlintest/SpecExtension.kt
@@ -51,7 +51,7 @@ object Project {
     synchronized(executedAfter) {
       if (!executedAfter) {
         projectConfig?.extensions?.forEach { extension -> extension.afterAll() }
-        executedAfter = false
+        executedAfter = true
       }
     }
   }

--- a/src/main/kotlin/io/kotlintest/SpecExtension.kt
+++ b/src/main/kotlin/io/kotlintest/SpecExtension.kt
@@ -44,7 +44,6 @@ object Project {
         executedBefore = true
       }
     }
-
   }
 
   fun afterAll() {

--- a/src/main/kotlin/io/kotlintest/SpecExtension.kt
+++ b/src/main/kotlin/io/kotlintest/SpecExtension.kt
@@ -1,0 +1,66 @@
+package io.kotlintest
+
+import org.reflections.Reflections
+
+interface SpecExtension {
+  fun beforeAll(context: TestBase) {}
+  fun beforeEach(context: TestCaseContext) {}
+  fun afterEach(context: TestCaseContext) {}
+  fun afterAll(context: TestBase) {}
+}
+
+
+data class TestCaseContext(
+    val spec: TestBase,
+    val testCase: TestCase,
+    val failure: Throwable? = null)
+
+
+interface ProjectExtension {
+  fun beforeAll() {}
+  fun afterAll() {}
+}
+
+
+abstract class ProjectConfig {
+  open val extensions: List<ProjectExtension> = listOf()
+}
+
+
+object Project {
+
+  private var projectConfig: ProjectConfig? = null
+  private var executedBefore = false
+  private var executedAfter = false
+
+  init {
+    val configClasses = Reflections("io.kotlintest").getSubTypesOf(ProjectConfig::class.java)
+    if (configClasses.size > 1)  {
+      val configClassNames = configClasses.map { config -> config.typeName }
+      throw InvalidConfigException("Duplicate GlobalConfig found: $configClassNames")
+    }
+    projectConfig = configClasses.firstOrNull()?.kotlin?.objectInstance
+  }
+
+  fun beforeAll() {
+    synchronized(executedBefore) {
+      if (!executedBefore) {
+        projectConfig?.extensions?.forEach { extension -> extension.beforeAll() }
+        executedBefore = true
+      }
+    }
+
+  }
+
+  fun afterAll() {
+    synchronized(executedAfter) {
+      if (!executedAfter) {
+        projectConfig?.extensions?.forEach { extension -> extension.afterAll() }
+        executedAfter = false
+      }
+    }
+  }
+}
+
+
+class InvalidConfigException(message: String) : Exception(message)

--- a/src/main/kotlin/io/kotlintest/SpecExtension.kt
+++ b/src/main/kotlin/io/kotlintest/SpecExtension.kt
@@ -2,23 +2,29 @@ package io.kotlintest
 
 import org.reflections.Reflections
 
-interface SpecExtension {
-  fun beforeAll(context: TestBase) {}
-  fun beforeEach(context: TestCaseContext) {}
-  fun afterEach(context: TestCaseContext) {}
-  fun afterAll(context: TestBase) {}
+interface TestCaseInterceptor {
+  operator fun invoke(context: TestCaseContext, callable: () -> Unit) {
+    callable()
+  }
 }
 
+interface SpecInterceptor {
+  operator fun invoke(context: TestBase, callable: () -> Unit) {
+    callable()
+  }
+}
 
 data class TestCaseContext(
     val spec: TestBase,
-    val testCase: TestCase,
-    val failure: Throwable? = null)
+    val testCase: TestCase)
 
 
 interface ProjectExtension {
   fun beforeAll() {}
   fun afterAll() {}
+  fun aroundProject(project: () -> Unit) {
+    project()
+  }
 }
 
 

--- a/src/main/kotlin/io/kotlintest/SpecExtension.kt
+++ b/src/main/kotlin/io/kotlintest/SpecExtension.kt
@@ -4,21 +4,14 @@ package io.kotlintest
 
 import org.reflections.Reflections
 
-interface SpecInterceptor {
-  operator fun invoke(context: TestBase, callable: () -> Unit) {
-    callable()
-  }
-}
-
 data class TestCaseContext(
     val spec: TestBase,
     val testCase: TestCase)
 
-
 interface ProjectExtension {
   fun beforeAll() {}
   fun afterAll() {}
-  fun aroundProject(project: () -> Unit) {
+  fun interceptProject(project: () -> Unit) {
     project()
   }
 }

--- a/src/main/kotlin/io/kotlintest/SpecExtension.kt
+++ b/src/main/kotlin/io/kotlintest/SpecExtension.kt
@@ -11,14 +11,16 @@ data class TestCaseContext(
 interface ProjectExtension {
   fun beforeAll() {}
   fun afterAll() {}
-  fun interceptProject(project: () -> Unit) {
-    project()
-  }
 }
 
 
 abstract class ProjectConfig {
+
   open val extensions: List<ProjectExtension> = listOf()
+
+  open fun beforeAll() {}
+
+  open fun afterAll() {}
 }
 
 
@@ -41,6 +43,7 @@ object Project {
     synchronized(executedBefore) {
       if (!executedBefore) {
         projectConfig?.extensions?.forEach { extension -> extension.beforeAll() }
+        projectConfig?.beforeAll()
         executedBefore = true
       }
     }
@@ -49,6 +52,7 @@ object Project {
   fun afterAll() {
     synchronized(executedAfter) {
       if (!executedAfter) {
+        projectConfig?.afterAll()
         projectConfig?.extensions?.forEach { extension -> extension.afterAll() }
         executedAfter = true
       }

--- a/src/main/kotlin/io/kotlintest/SpecExtension.kt
+++ b/src/main/kotlin/io/kotlintest/SpecExtension.kt
@@ -1,12 +1,8 @@
 package io.kotlintest
 
-import org.reflections.Reflections
+// TODO rename and split file
 
-interface TestCaseInterceptor {
-  operator fun invoke(context: TestCaseContext, testCase: () -> Unit) {
-    testCase()
-  }
-}
+import org.reflections.Reflections
 
 interface SpecInterceptor {
   operator fun invoke(context: TestBase, callable: () -> Unit) {

--- a/src/main/kotlin/io/kotlintest/TestBase.kt
+++ b/src/main/kotlin/io/kotlintest/TestBase.kt
@@ -114,10 +114,9 @@ abstract class TestBase : PropertyTesting(), Matchers, TableTesting {
         interceptTestCase(context, { testCase() })
       }
 
-      val interceptorChain = testCase.config.interceptors.reversed().fold<(TestCaseContext, () -> Unit) -> Unit, (TestCaseContext, () -> Unit) -> Unit>(initial) {
-        a, b ->
-
-        { context: TestCaseContext, testCase: () -> Unit ->
+      val interceptorChain = testCase.config.interceptors.reversed().fold(initial) { a, b ->
+        {
+          context: TestCaseContext, testCase: () -> Unit ->
           b.invoke(context, { a.invoke(context, { testCase() }) })
         }
 

--- a/src/main/kotlin/io/kotlintest/TestBase.kt
+++ b/src/main/kotlin/io/kotlintest/TestBase.kt
@@ -116,14 +116,14 @@ abstract class TestBase : PropertyTesting(), Matchers, TableTesting {
       notifier.fireTestStarted(testCase.description)
 
       val initial = object : TestCaseInterceptor {
-        override fun invoke(context: TestCaseContext, callable: () -> Unit) {
-          aroundTest(context, { callable() })
+        override fun invoke(context: TestCaseContext, testCase: () -> Unit) {
+          aroundTest(context, { testCase() })
         }
       }
       val interceptorChain = extensions.reversed().fold(initial) { a: TestCaseInterceptor, b: TestCaseInterceptor ->
         object : TestCaseInterceptor {
-          override fun invoke(context: TestCaseContext, callable: () -> Unit) {
-            b.invoke(context, { a.invoke(context, { callable() }) })
+          override fun invoke(context: TestCaseContext, testCase: () -> Unit) {
+            b.invoke(context, { a.invoke(context, { testCase() }) })
           }
         }
       }

--- a/src/main/kotlin/io/kotlintest/TestBase.kt
+++ b/src/main/kotlin/io/kotlintest/TestBase.kt
@@ -42,7 +42,7 @@ abstract class TestBase : PropertyTesting(), Matchers, TableTesting {
    * Interceptors that intercepts the execution of the whole spec. Interceptors are executed from
    * left to right.
    */
-  protected open val specInterceptors: Iterable<(TestBase, () -> Unit) -> Unit> = listOf()
+  protected open val specInterceptors: List<(TestBase, () -> Unit) -> Unit> = listOf()
 
   private val closeablesInReverseOrder = LinkedList<Closeable>()
 

--- a/src/main/kotlin/io/kotlintest/TestBase.kt
+++ b/src/main/kotlin/io/kotlintest/TestBase.kt
@@ -181,12 +181,22 @@ abstract class TestBase : PropertyTesting(), Matchers, TableTesting {
     }
   }
 
-  // TODO write documentation
+  /**
+   * Intercepts the call of each test case.
+   *
+   * Don't forget to call `test()` in the body of this method. Otherwise the test case will never be
+   * executed.
+   */
   protected open fun interceptTestCase(context: TestCaseContext, test: () -> Unit) {
     test()
   }
 
-  // TODO write documentation
+  /**
+   * Intercepts the call of whole spec.
+   *
+   * Don't forget to call `spec()` in the body of this method. Otherwise the spec will never be
+   * executed.
+   */
   protected open fun interceptSpec(context: TestBase, spec: () -> Unit) {
     spec()
   }

--- a/src/main/kotlin/io/kotlintest/TestBase.kt
+++ b/src/main/kotlin/io/kotlintest/TestBase.kt
@@ -121,11 +121,15 @@ abstract class TestBase : PropertyTesting(), Matchers, TableTesting {
         val callable = Callable {
           performBeforeEach(spec, testCase)
           try {
-            testCase.test()
-            performAfterEach(spec, testCase, null)
+            try {
+              testCase.test()
+              performAfterEach(spec, testCase, null)
+            } catch (exception: Throwable) {
+              performAfterEach(spec, testCase, exception)
+              // afterEach would need to rethrow the exception, to gain a failure
+              // alternative: throw exception
+            }
           } catch (e: Throwable) {
-            performAfterEach(spec, testCase, e)
-            // TODO is it correct to create a Failure in any case although the performAfterEach method could handle the exception?
             Failure(testCase.description, e)
           }
         }

--- a/src/main/kotlin/io/kotlintest/TestBase.kt
+++ b/src/main/kotlin/io/kotlintest/TestBase.kt
@@ -36,6 +36,10 @@ abstract class TestBase : PropertyTesting(), Matchers, TableTesting {
    */
   protected open val defaultTestCaseConfig: TestConfig = TestConfig()
 
+  /**
+   * Interceptors that intercepts the execution of the whole spec. Interceptors are executed from
+   * left to right.
+   */
   protected open val interceptors: Iterable<(TestBase, () -> Unit) -> Unit> = listOf()
 
   private val closeablesInReverseOrder = LinkedList<Closeable>()
@@ -177,10 +181,12 @@ abstract class TestBase : PropertyTesting(), Matchers, TableTesting {
     }
   }
 
+  // TODO write documentation
   protected open fun interceptTestCase(context: TestCaseContext, test: () -> Unit) {
     test()
   }
 
+  // TODO write documentation
   protected open fun interceptSpec(context: TestBase, spec: () -> Unit) {
     spec()
   }

--- a/src/main/kotlin/io/kotlintest/TestBase.kt
+++ b/src/main/kotlin/io/kotlintest/TestBase.kt
@@ -40,7 +40,7 @@ abstract class TestBase : PropertyTesting(), Matchers, TableTesting {
    * Interceptors that intercepts the execution of the whole spec. Interceptors are executed from
    * left to right.
    */
-  protected open val interceptors: Iterable<(TestBase, () -> Unit) -> Unit> = listOf()
+  protected open val specInterceptors: Iterable<(TestBase, () -> Unit) -> Unit> = listOf()
 
   private val closeablesInReverseOrder = LinkedList<Closeable>()
 
@@ -50,7 +50,7 @@ abstract class TestBase : PropertyTesting(), Matchers, TableTesting {
     val initialInterceptor = { context: TestBase, testCase: () -> Unit ->
       interceptSpec(context, { testCase() })
     }
-    val interceptorChain = createInterceptorChain(interceptors, initialInterceptor)
+    val interceptorChain = createInterceptorChain(specInterceptors, initialInterceptor)
 
     interceptorChain(this, {
       if (oneInstancePerTest)

--- a/src/main/kotlin/io/kotlintest/TestCaseContext.kt
+++ b/src/main/kotlin/io/kotlintest/TestCaseContext.kt
@@ -1,0 +1,8 @@
+package io.kotlintest
+
+/**
+ * Meta information about a [TestCase].
+ */
+data class TestCaseContext(
+    val spec: TestBase,
+    val testCase: TestCase)

--- a/src/main/kotlin/io/kotlintest/TestConfig.kt
+++ b/src/main/kotlin/io/kotlintest/TestConfig.kt
@@ -7,7 +7,7 @@ class TestConfig(
     val threads: Int = 1,
     tags: Set<Tag> = setOf(),
     tag: Tag? = null,
-    val interceptors: Iterable<TestCaseInterceptor> = listOf()) {
+    val interceptors: Iterable<(TestCaseContext, () -> Unit) -> Unit> = listOf()) {
 
   val tags = if (tag != null) tags + tag else tags
 
@@ -17,7 +17,7 @@ class TestConfig(
       timeout: Duration = this.timeout,
       threads: Int = this.threads,
       tags: Set<Tag> = this.tags,
-      interceptors: Iterable<TestCaseInterceptor> = this.interceptors) =
+      interceptors: Iterable<(TestCaseContext, () -> Unit) -> Unit> = this.interceptors) =
       TestConfig(
           ignored = ignored,
           invocations = invocations,

--- a/src/main/kotlin/io/kotlintest/TestConfig.kt
+++ b/src/main/kotlin/io/kotlintest/TestConfig.kt
@@ -6,7 +6,8 @@ class TestConfig(
     val timeout: Duration = Duration.unlimited,
     val threads: Int = 1,
     tags: Set<Tag> = setOf(),
-    tag: Tag? = null) {
+    tag: Tag? = null,
+    val interceptors: Iterable<TestCaseInterceptor> = listOf()) {
 
   val tags = if (tag != null) tags + tag else tags
 
@@ -15,5 +16,13 @@ class TestConfig(
       invocations: Int = this.invocations,
       timeout: Duration = this.timeout,
       threads: Int = this.threads,
-      tags: Set<Tag> = this.tags) = TestConfig(ignored, invocations, timeout, threads, tags)
+      tags: Set<Tag> = this.tags,
+      interceptors: Iterable<TestCaseInterceptor> = this.interceptors) =
+      TestConfig(
+          ignored = ignored,
+          invocations = invocations,
+          timeout = timeout,
+          threads = threads,
+          tags = tags,
+          interceptors = interceptors)
 }

--- a/src/main/kotlin/io/kotlintest/TestSuite.kt
+++ b/src/main/kotlin/io/kotlintest/TestSuite.kt
@@ -9,7 +9,7 @@ data class TestSuite(
     fun empty(name: String) = TestSuite(name, mutableListOf<TestSuite>(), mutableListOf<TestCase>())
   }
 
-  internal fun tests(suite: TestSuite = this): List<TestCase> =
+  fun tests(suite: TestSuite = this): List<TestCase> =
       suite.cases + suite.nestedSuites.flatMap { suite -> tests(suite) }
 
   internal val size = tests().size

--- a/src/main/kotlin/io/kotlintest/testcase.kt
+++ b/src/main/kotlin/io/kotlintest/testcase.kt
@@ -24,7 +24,7 @@ data class TestCase(
       threads: Int? = null,
       tag: Tag? = null,
       tags: Set<Tag>? = null,
-      interceptors: Iterable<TestCaseInterceptor>? = null) {
+      interceptors: Iterable<(TestCaseContext, () -> Unit) -> Unit>? = null) {
     config =
         TestConfig(
             ignored ?: config.ignored,

--- a/src/main/kotlin/io/kotlintest/testcase.kt
+++ b/src/main/kotlin/io/kotlintest/testcase.kt
@@ -13,14 +13,18 @@ data class TestCase(
         suite.name.replace('.', ' '),
         if (config.invocations < 2) name else name + " (${config.invocations} invocations)")
 
-  // TODO add interceptors
+  /**
+   * @param interceptors Interceptors around the test case. Interceptors are processed from left to
+   * right.
+   */
   fun config(
       invocations: Int? = null,
       ignored: Boolean? = null,
       timeout: Duration? = null,
       threads: Int? = null,
       tag: Tag? = null,
-      tags: Set<Tag>? = null) {
+      tags: Set<Tag>? = null,
+      interceptors: Iterable<TestCaseInterceptor>? = null) {
     config =
         TestConfig(
             ignored ?: config.ignored,
@@ -28,7 +32,8 @@ data class TestCase(
             timeout ?: config.timeout,
             threads ?: config.threads,
             tags ?: config.tags,
-            tag)
+            tag,
+            interceptors ?: config.interceptors)
   }
 
   val isActive: Boolean

--- a/src/main/kotlin/io/kotlintest/testcase.kt
+++ b/src/main/kotlin/io/kotlintest/testcase.kt
@@ -13,6 +13,7 @@ data class TestCase(
         suite.name.replace('.', ' '),
         if (config.invocations < 2) name else name + " (${config.invocations} invocations)")
 
+  // TODO add interceptors
   fun config(
       invocations: Int? = null,
       ignored: Boolean? = null,
@@ -30,7 +31,7 @@ data class TestCase(
             tag)
   }
 
-  internal val isActive: Boolean
+  val isActive: Boolean
     get() = !config.ignored && isActiveAccordingToTags
 
   private val isActiveAccordingToTags: Boolean

--- a/src/test/kotlin/io/kotlintest/ConfigTest.kt
+++ b/src/test/kotlin/io/kotlintest/ConfigTest.kt
@@ -8,37 +8,36 @@ class ConfigTest : WordSpec() {
 
   object TagA : Tag()
 
-  val specInterceptorLog = StringBuilder()
   val testCaseInterceptorLog: ThreadLocal<StringBuilder>? = ThreadLocal.withInitial { StringBuilder() }
 
   val verificationInterceptor: (TestBase, () -> Unit) -> Unit = { context, spec ->
     spec()
-    val expectedLog = "A1.B1.C1.D1.test call.D2.C2.B2.A2."
-    specInterceptorLog.toString() shouldEqual expectedLog
+    val expectedLog = "A1.B1.C1.D1.E1.F1.test call.F2.E2.D2.C2."
+    DemoConfig.intercepterLog.toString() shouldEqual expectedLog
   }
 
   val specInterceptorA: (TestBase, () -> Unit) -> Unit = { context, spec ->
-    specInterceptorLog.append("A1.")
+    DemoConfig.intercepterLog.append("C1.")
     spec()
-    specInterceptorLog.append("A2.")
+    DemoConfig.intercepterLog.append("C2.")
   }
 
   val specInterceptorB: (TestBase, () -> Unit) -> Unit = { context, spec ->
-    specInterceptorLog.append("B1.")
+    DemoConfig.intercepterLog.append("D1.")
     spec()
-    specInterceptorLog.append("B2.")
+    DemoConfig.intercepterLog.append("D2.")
   }
 
   val testCaseinterceptorC: (TestCaseContext, () -> Unit) -> Unit = { context, testCase ->
-    testCaseInterceptorLog!!.get().append("C1.")
+    testCaseInterceptorLog!!.get().append("E1.")
     testCase()
-    testCaseInterceptorLog!!.get().append("C2.")
+    testCaseInterceptorLog!!.get().append("E2.")
   }
 
   val testCaseInterceptorD: (TestCaseContext, () -> Unit) -> Unit = { context, testCase ->
-    testCaseInterceptorLog!!.get().append("D1.")
+    testCaseInterceptorLog!!.get().append("F1.")
     testCase()
-    testCaseInterceptorLog!!.get().append("D2.")
+    testCaseInterceptorLog!!.get().append("F2.")
   }
 
   val testCaseInterceptorE = { context: TestCaseContext, testCase: () -> Unit ->
@@ -108,7 +107,7 @@ class ConfigTest : WordSpec() {
 
       val orderVerificationInterceptor: (TestCaseContext, () -> Unit) -> Unit = { context, testCase ->
         testCase()
-        specInterceptorLog.append(testCaseInterceptorLog!!.get().toString())
+        DemoConfig.intercepterLog.append(testCaseInterceptorLog!!.get().toString())
       }
       "should call interceptors in order of definition" {
         testCaseInterceptorLog!!.get().append("test call.")

--- a/src/test/kotlin/io/kotlintest/ConfigTest.kt
+++ b/src/test/kotlin/io/kotlintest/ConfigTest.kt
@@ -56,7 +56,7 @@ class ConfigTest : WordSpec() {
           tag = TagA,
           interceptors = testCaseInterceptors)
 
-  override val interceptors = listOf(verificationInterceptor, specInterceptorA, specInterceptorB)
+  override val specInterceptors = listOf(verificationInterceptor, specInterceptorA, specInterceptorB)
 
   override val oneInstancePerTest = false
 

--- a/src/test/kotlin/io/kotlintest/ConfigTest.kt
+++ b/src/test/kotlin/io/kotlintest/ConfigTest.kt
@@ -12,7 +12,7 @@ class ConfigTest : WordSpec() {
       config(
           invocations = 3,
           tag = TagA,
-          interceptors = listOf(InterceptorA, InterceptorB, InterceptorC))
+          interceptors = listOf(::interceptorA, ::interceptorB, ::interceptorC))
 
   override val oneInstancePerTest = false
 
@@ -79,26 +79,22 @@ class ConfigTest : WordSpec() {
   }
 }
 
-object InterceptorA : TestCaseInterceptor {
-  override fun invoke(context: TestCaseContext, testCase: () -> Unit) {
-    println("A") // TODO replace with assertion
-    testCase()
-  }
+fun interceptorA(context: TestCaseContext, testCase: () -> Unit) {
+  println("A") // TODO replace with assertion
+  testCase()
 }
 
-object InterceptorB : TestCaseInterceptor {
-  override fun invoke(context: TestCaseContext, testCase: () -> Unit) {
-    println("B") // TODO replace with assertion
-    testCase()
-  }
+
+fun interceptorB(context: TestCaseContext, testCase: () -> Unit) {
+  println("B") // TODO replace with assertion
+  testCase()
 }
 
-object InterceptorC : TestCaseInterceptor {
-  override fun invoke(context: TestCaseContext, testCase: () -> Unit) {
-    try {
-      testCase()
-    } catch (ex: RuntimeException) {
-      println("caught") // TODO replace with assertion
-    }
+
+fun interceptorC(context: TestCaseContext, testCase: () -> Unit) {
+  try {
+    testCase()
+  } catch (ex: RuntimeException) {
+    println("caught") // TODO replace with assertion
   }
 }

--- a/src/test/kotlin/io/kotlintest/ConfigTest.kt
+++ b/src/test/kotlin/io/kotlintest/ConfigTest.kt
@@ -8,9 +8,13 @@ class ConfigTest : WordSpec() {
 
   object TagA : Tag()
 
-  override val defaultTestCaseConfig: TestConfig = config(invocations = 3, tag = TagA)
+  override val defaultTestCaseConfig: TestConfig =
+      config(
+          invocations = 3,
+          tag = TagA,
+          interceptors = listOf(InterceptorA, InterceptorB, InterceptorC))
+
   override val oneInstancePerTest = false
-  override val extensions = listOf(InterceptorA, InterceptorB, InterceptorC)
 
   val invocationCounter = AtomicInteger(0)
   val invocationCounter2 = AtomicInteger(0)
@@ -58,7 +62,11 @@ class ConfigTest : WordSpec() {
 
       "should handle exception with interceptor" {
         throw RuntimeException()
-      }
+      }.config(invocations = 1)
+
+      "should override interceptors" {
+        // TODO test, that no interceptor has been called
+      }.config(interceptors = listOf())
     }
   }
 
@@ -85,7 +93,7 @@ object InterceptorB : TestCaseInterceptor {
   }
 }
 
-object InterceptorC: TestCaseInterceptor {
+object InterceptorC : TestCaseInterceptor {
   override fun invoke(context: TestCaseContext, testCase: () -> Unit) {
     try {
       testCase()

--- a/src/test/kotlin/io/kotlintest/ConfigTest.kt
+++ b/src/test/kotlin/io/kotlintest/ConfigTest.kt
@@ -72,23 +72,23 @@ class ConfigTest : WordSpec() {
 }
 
 object InterceptorA : TestCaseInterceptor {
-  override fun invoke(context: TestCaseContext, test: () -> Unit) {
+  override fun invoke(context: TestCaseContext, testCase: () -> Unit) {
     println("A") // TODO replace with assertion
-    test()
+    testCase()
   }
 }
 
 object InterceptorB : TestCaseInterceptor {
-  override fun invoke(context: TestCaseContext, test: () -> Unit) {
+  override fun invoke(context: TestCaseContext, testCase: () -> Unit) {
     println("B") // TODO replace with assertion
-    test()
+    testCase()
   }
 }
 
 object InterceptorC: TestCaseInterceptor {
-  override fun invoke(context: TestCaseContext, test: () -> Unit) {
+  override fun invoke(context: TestCaseContext, testCase: () -> Unit) {
     try {
-      test()
+      testCase()
     } catch (ex: RuntimeException) {
       println("caught") // TODO replace with assertion
     }

--- a/src/test/kotlin/io/kotlintest/ConfigTest.kt
+++ b/src/test/kotlin/io/kotlintest/ConfigTest.kt
@@ -14,6 +14,8 @@ class ConfigTest : WordSpec() {
           tag = TagA,
           interceptors = listOf(::interceptorA, ::interceptorB, ::interceptorC))
 
+  override val interceptors = listOf(::specInterceptorA, ::specInterceptorB)
+
   override val oneInstancePerTest = false
 
   val invocationCounter = AtomicInteger(0)
@@ -70,13 +72,26 @@ class ConfigTest : WordSpec() {
     }
   }
 
-  override fun aroundSpec(context: TestBase, spec: () -> Unit): Unit {
+  override fun interceptSpec(context: TestBase, spec: () -> Unit): Unit {
     spec()
 
     invocationCounter.get() shouldBe 5
     invocationCounter2.get() shouldBe 3
     threadCounter.get() shouldBe 100
   }
+}
+
+fun specInterceptorA(context: TestBase, spec: () -> Unit) {
+  println("A before spec")
+  spec()
+  println("A after spec")
+}
+
+
+fun specInterceptorB(context: TestBase, spec: () -> Unit) {
+  println("B before spec")
+  spec()
+  println("B after spec")
 }
 
 fun interceptorA(context: TestCaseContext, testCase: () -> Unit) {

--- a/src/test/kotlin/io/kotlintest/ConfigTest.kt
+++ b/src/test/kotlin/io/kotlintest/ConfigTest.kt
@@ -8,7 +8,9 @@ class ConfigTest : WordSpec() {
 
   object TagA : Tag()
 
-  val testCaseInterceptorLog: ThreadLocal<StringBuilder>? = ThreadLocal.withInitial { StringBuilder() }
+  val testCaseInterceptorLog: ThreadLocal<StringBuilder>? = object : ThreadLocal<StringBuilder>() {
+    override fun initialValue() = StringBuilder()
+  }
 
   val verificationInterceptor: (TestBase, () -> Unit) -> Unit = { context, spec ->
     spec()

--- a/src/test/kotlin/io/kotlintest/ConfigTest.kt
+++ b/src/test/kotlin/io/kotlintest/ConfigTest.kt
@@ -109,9 +109,10 @@ class ConfigTest : WordSpec() {
         testCase()
         DemoConfig.intercepterLog.append(testCaseInterceptorLog!!.get().toString())
       }
+
       "should call interceptors in order of definition" {
         testCaseInterceptorLog!!.get().append("test call.")
-      }.config(invocations = 1, interceptors = listOf(orderVerificationInterceptor) + testCaseInterceptors) // TODO introcude "additionalInterceptors"?
+      }.config(invocations = 1, interceptors = listOf(orderVerificationInterceptor) + testCaseInterceptors)
 
       "should handle exception with interceptor" {
         throw RuntimeException()

--- a/src/test/kotlin/io/kotlintest/ConfigTest.kt
+++ b/src/test/kotlin/io/kotlintest/ConfigTest.kt
@@ -8,13 +8,43 @@ class ConfigTest : WordSpec() {
 
   object TagA : Tag()
 
+  val specInterceptorA = { context: TestBase, spec: () -> Unit ->
+    println("A before spec")
+    spec()
+    println("A after spec")
+  }
+
+  val specInterceptorB = { context: TestBase, spec: () -> Unit ->
+    println("B before spec")
+    spec()
+    println("B after spec")
+  }
+
+  val interceptorA = { context: TestCaseContext, testCase: () -> Unit ->
+    println("A") // TODO replace with assertion
+    testCase()
+  }
+
+  val interceptorB = {context: TestCaseContext, testCase: () -> Unit ->
+    println("B") // TODO replace with assertion
+    testCase()
+  }
+
+  val interceptorC = {context: TestCaseContext, testCase: () -> Unit ->
+    try {
+      testCase()
+    } catch (ex: RuntimeException) {
+      println("caught") // TODO replace with assertion
+    }
+  }
+
   override val defaultTestCaseConfig: TestConfig =
       config(
           invocations = 3,
           tag = TagA,
-          interceptors = listOf(::interceptorA, ::interceptorB, ::interceptorC))
+          interceptors = listOf(interceptorA, interceptorB, interceptorC))
 
-  override val interceptors = listOf(::specInterceptorA, ::specInterceptorB)
+  override val interceptors = listOf(specInterceptorA, specInterceptorB)
 
   override val oneInstancePerTest = false
 
@@ -79,37 +109,8 @@ class ConfigTest : WordSpec() {
     invocationCounter2.get() shouldBe 3
     threadCounter.get() shouldBe 100
   }
-}
 
-fun specInterceptorA(context: TestBase, spec: () -> Unit) {
-  println("A before spec")
-  spec()
-  println("A after spec")
+
 }
 
 
-fun specInterceptorB(context: TestBase, spec: () -> Unit) {
-  println("B before spec")
-  spec()
-  println("B after spec")
-}
-
-fun interceptorA(context: TestCaseContext, testCase: () -> Unit) {
-  println("A") // TODO replace with assertion
-  testCase()
-}
-
-
-fun interceptorB(context: TestCaseContext, testCase: () -> Unit) {
-  println("B") // TODO replace with assertion
-  testCase()
-}
-
-
-fun interceptorC(context: TestCaseContext, testCase: () -> Unit) {
-  try {
-    testCase()
-  } catch (ex: RuntimeException) {
-    println("caught") // TODO replace with assertion
-  }
-}

--- a/src/test/kotlin/io/kotlintest/ConfigTest.kt
+++ b/src/test/kotlin/io/kotlintest/ConfigTest.kt
@@ -1,9 +1,8 @@
 package io.kotlintest
 
-import io.kotlintest.specs.WordSpec
-import java.util.concurrent.atomic.AtomicBoolean
-import java.util.concurrent.atomic.AtomicInteger
 import io.kotlintest.Duration.Companion.milliseconds
+import io.kotlintest.specs.WordSpec
+import java.util.concurrent.atomic.AtomicInteger
 
 class ConfigTest : WordSpec() {
 

--- a/src/test/kotlin/io/kotlintest/DemoConfig.kt
+++ b/src/test/kotlin/io/kotlintest/DemoConfig.kt
@@ -12,20 +12,10 @@ object DemoConfig : ProjectConfig() {
     intercepterLog.append("B1.")
     started = System.currentTimeMillis()
   }
-
-  override fun afterAll() {
-    val time = System.currentTimeMillis() - started
-    println("overall time [ms]: " + time) // TODO replace with proper test
-  }
 }
 
 object TestExtension : ProjectExtension {
   override fun beforeAll() {
     DemoConfig.intercepterLog.append("A1.")
-    println("before all extension") // TODO replace with proper test
-  }
-
-  override fun afterAll() {
-    println("after all extension") // TODO replace with proper test
   }
 }

--- a/src/test/kotlin/io/kotlintest/DemoConfig.kt
+++ b/src/test/kotlin/io/kotlintest/DemoConfig.kt
@@ -6,11 +6,8 @@ object DemoConfig : ProjectConfig() {
 
   val intercepterLog = StringBuilder()
 
-  private var started: Long = 0
-
   override fun beforeAll() {
     intercepterLog.append("B1.")
-    started = System.currentTimeMillis()
   }
 }
 

--- a/src/test/kotlin/io/kotlintest/DemoConfig.kt
+++ b/src/test/kotlin/io/kotlintest/DemoConfig.kt
@@ -1,0 +1,15 @@
+package io.kotlintest;
+
+object DemoConfig : ProjectConfig() {
+  override val extensions = listOf(TestExtension)
+}
+
+object TestExtension : ProjectExtension {
+  override fun beforeAll() {
+    println("before all")
+  }
+
+  override fun afterAll() {
+    println("after all")
+  }
+}

--- a/src/test/kotlin/io/kotlintest/DemoConfig.kt
+++ b/src/test/kotlin/io/kotlintest/DemoConfig.kt
@@ -1,15 +1,27 @@
 package io.kotlintest;
 
 object DemoConfig : ProjectConfig() {
+
   override val extensions = listOf(TestExtension)
+
+  private var started: Long = 0
+
+  override fun beforeAll() {
+    started = System.currentTimeMillis()
+  }
+
+  override fun afterAll() {
+    val time = System.currentTimeMillis() - started
+    println("overall time [ms]: " + time) // TODO replace with proper test
+  }
 }
 
 object TestExtension : ProjectExtension {
   override fun beforeAll() {
-    println("before all")
+    println("before all extension") // TODO replace with proper test
   }
 
   override fun afterAll() {
-    println("after all")
+    println("after all extension") // TODO replace with proper test
   }
 }

--- a/src/test/kotlin/io/kotlintest/DemoConfig.kt
+++ b/src/test/kotlin/io/kotlintest/DemoConfig.kt
@@ -4,9 +4,12 @@ object DemoConfig : ProjectConfig() {
 
   override val extensions = listOf(TestExtension)
 
+  val intercepterLog = StringBuilder()
+
   private var started: Long = 0
 
   override fun beforeAll() {
+    intercepterLog.append("B1.")
     started = System.currentTimeMillis()
   }
 
@@ -18,6 +21,7 @@ object DemoConfig : ProjectConfig() {
 
 object TestExtension : ProjectExtension {
   override fun beforeAll() {
+    DemoConfig.intercepterLog.append("A1.")
     println("before all extension") // TODO replace with proper test
   }
 

--- a/src/test/kotlin/io/kotlintest/TestCaseTest.kt
+++ b/src/test/kotlin/io/kotlintest/TestCaseTest.kt
@@ -31,7 +31,7 @@ class TestCaseTest : StringSpec() {
     }.config(tag = TagA)
   }
 
-  override fun aroundTest(contex: TestCaseContext, test: () -> Unit) {
+  override fun interceptTestCase(contex: TestCaseContext, test: () -> Unit) {
     test()
     System.clearProperty("excludeTags")
     System.clearProperty("includeTags")

--- a/src/test/kotlin/io/kotlintest/TestCaseTest.kt
+++ b/src/test/kotlin/io/kotlintest/TestCaseTest.kt
@@ -31,7 +31,8 @@ class TestCaseTest : StringSpec() {
     }.config(tag = TagA)
   }
 
-  override fun afterEach() {
+  override fun aroundTest(contex: TestCaseContext, test: () -> Unit) {
+    test()
     System.clearProperty("excludeTags")
     System.clearProperty("includeTags")
   }


### PR DESCRIPTION
I decided to leave the `ProjectExtension` interface as is (and not split it), because the user had to take care of the order of separately registered `beforeAll` and `afterAll` methods otherwise, while the framework can easily manage this.