### PR TITLE
Remove overhead in Gen.oneOf(vararg Gen)

### DIFF
--- a/src/main/kotlin/io/kotlintest/properties/Gen.kt
+++ b/src/main/kotlin/io/kotlintest/properties/Gen.kt
@@ -27,10 +27,7 @@ interface Gen<T> {
       }
     }
 
-    fun <T> oneOf(vararg generators: Gen<T>): Gen<T> = object : Gen<T> {
-      override fun generate(): T = Gen.oneOf(generators.toList()).generate().generate()
-
-    }
+    fun <T> oneOf(vararg generators: Gen<T>): Gen<T> = oneOf(generators.toList())
 
     fun <T> oneOf(values: List<T>): Gen<T> = object : Gen<T> {
       override fun generate(): T = values[RANDOM.nextInt(values.size)]


### PR DESCRIPTION
Previous implementation creates too much junk too easily. I just bumped into this piece of code when learning this framework. The newline at the EOF is added by Github web editor. I can't remove it without cloning the entire repo.