### PR TITLE
Minor testfix for "should endWith"-tests

### DIFF
--- a/src/test/kotlin/io/kotlintest/matchers/StringMatchersTest.kt
+++ b/src/test/kotlin/io/kotlintest/matchers/StringMatchersTest.kt
@@ -8,8 +8,8 @@ class StringMatchersTest : FreeSpec(), Matchers {
     "should endWith" - {
       "should test strings" {
         "hello" should endWith("o")
-        "hello" should startWith("")
-        "" should startWith("")
+        "hello" should endWith("")
+        "" should endWith("")
         shouldThrow<AssertionError> {
           "" should endWith("h")
         }


### PR DESCRIPTION
Really just a small fix.
There were two cases in which the "should endWith"-test used `startWith` instead of `endWith`