### PR TITLE
FIX Merge

### DIFF
--- a/src/main/kotlin/io/kotlintest/matchers/ComparableMatchers.kt
+++ b/src/main/kotlin/io/kotlintest/matchers/ComparableMatchers.kt
@@ -1,30 +1,5 @@
 package io.kotlintest.matchers
 
-@Deprecated("Use `value shouldBe lt(x)` or `value should beLessThan(x)`")
-infix fun <T> MatcherBuilder<be, T>.lt(expected: Comparable<T>): Unit {
-  if (expected <= value)
-    throw AssertionError("$value is not less than $expected")
-}
-
-@Deprecated("Use `value shouldBe lte(x)` or `value should beLessOrEqualTo(x)`")
-infix fun <T> MatcherBuilder<be, T>.lte(expected: Comparable<T>): Unit {
-  if (expected < value)
-    throw AssertionError("$value should be less than or equal to $expected")
-}
-
-@Deprecated("Use `value shouldBe gt(x)` or `value should beGreaterThan(x)`")
-infix fun <T> MatcherBuilder<be, T>.gt(expected: Comparable<T>): Unit {
-  if (expected >= value)
-    throw AssertionError("$value is not less than $expected")
-}
-
-@Deprecated("Use `value shouldBe gte(x)` or `value should beGreaterThanOrEqualTo(x)`")
-infix fun <T> MatcherBuilder<be, T>.gte(expected: Comparable<T>): Unit {
-  if (expected > value)
-    throw AssertionError("$value should be less than or equal to $expected")
-}
-
-interface ComparableMatchers {
 
   fun <T> lt(x: T) = beLessThan(x)
   fun <T> beLessThan(x: T) = object : Matcher<Comparable<T>> {
@@ -45,5 +20,3 @@ interface ComparableMatchers {
   fun <T> beGreaterThanOrEqualTo(x: T) = object : Matcher<Comparable<T>> {
     override fun test(value: Comparable<T>) = Result(value >= x, "$value should be >= $x")
   }
-
-}

--- a/src/main/kotlin/io/kotlintest/matchers/Matchers.kt
+++ b/src/main/kotlin/io/kotlintest/matchers/Matchers.kt
@@ -10,36 +10,18 @@ fun fail(msg: String): Nothing = throw AssertionError(msg)
 
 infix fun Double.shouldBe(other: Double): Unit = should(ToleranceMatcher(other, 0.0))
 
-interface Matchers : StringMatchers,
-    CollectionMatchers,
-    ComparableMatchers,
-    DoubleMatchers,
-    IntMatchers,
-    LongMatchers,
-    FileMatchers,
-    MapMatchers,
-    TypeMatchers,
-    Inspectors {
-
-  fun <T> equalityMatcher(expected: T) = object : Matcher<T> {
-    override fun test(value: T): Result = Result(this == value, "$expected should equal $value")
-  }
-
-  fun fail(msg: String): Nothing = throw AssertionError(msg)
-
-  infix fun Double.shouldBe(other: Double): Unit = should(ToleranceMatcher(other, 0.0))
-
-  infix fun String.shouldBe(other: String) {
-    if (this != other) {
-      var msg = "String $this should be equal to $other"
-      for (k in 0..Math.min(this.length, other.length) - 1) {
-        if (this[k] != other[k]) {
-          msg = "$msg (diverged at index $k)"
-          break
-        }
-      throw AssertionError(msg)
+infix fun String.shouldBe(other: String) {
+  if (this != other) {
+    var msg = "String $this should be equal to $other"
+    for (k in 0..Math.min(this.length, other.length) - 1) {
+      if (this[k] != other[k]) {
+        msg = "$msg (diverged at index $k)"
+        break
+      }
     }
+    throw AssertionError(msg)
   }
+}
 
 infix fun BooleanArray.shouldBe(other: BooleanArray): Unit {
   if (this.toList() != other.toList())

--- a/src/test/kotlin/io/kotlintest/matchers/ComparableMatchersTest.kt
+++ b/src/test/kotlin/io/kotlintest/matchers/ComparableMatchersTest.kt
@@ -1,5 +1,6 @@
 package io.kotlintest.matchers
 
+import io.kotlintest.forAll
 import io.kotlintest.specs.FreeSpec
 
 class ComparableMatchersTest : FreeSpec() {
@@ -28,7 +29,6 @@ class ComparableMatchersTest : FreeSpec() {
           forAll(arrayOf(Pair(cn, cz), Pair(cz, cp))) {
             it.first shouldBe lt(it.second)
             it.first should beLessThan(it.second)
-            it.first should be lt it.second // Deprecated infix method
           }
         }
 
@@ -36,7 +36,6 @@ class ComparableMatchersTest : FreeSpec() {
           forAll(arrayOf(cn, cz, cp)) {
             shouldThrow<AssertionError> { it shouldBe lt(it) }
             shouldThrow<AssertionError> { it should beLessThan(it) }
-            shouldThrow<AssertionError> { it should be lt it } // Deprecated infix method
           }
         }
 
@@ -44,7 +43,6 @@ class ComparableMatchersTest : FreeSpec() {
           forAll(arrayOf(Pair(cp, cz), Pair(cz, cn))) {
             shouldThrow<AssertionError> { it.first shouldBe lt(it.second) }
             shouldThrow<AssertionError> { it.first should beLessThan(it.second) }
-            shouldThrow<AssertionError> { it.first should be lt it.second } // Deprecated infix method
           }
         }
 
@@ -56,7 +54,6 @@ class ComparableMatchersTest : FreeSpec() {
           forAll(arrayOf(Pair(cn, cn), Pair(cn, cz), Pair(cz, cz), Pair(cz, cp), Pair(cp, cp))) {
             it.first shouldBe lte(it.second)
             it.first should beLessThanOrEqualTo(it.second)
-            it.first should be lte it.second // Deprecated infix method
           }
         }
 
@@ -64,7 +61,6 @@ class ComparableMatchersTest : FreeSpec() {
           forAll(arrayOf(Pair(cp, cz), Pair(cz, cn))) {
             shouldThrow<AssertionError> { it.first shouldBe lte(it.second) }
             shouldThrow<AssertionError> { it.first should beLessThanOrEqualTo(it.second) }
-            shouldThrow<AssertionError> { it.first should be lte it.second } // Deprecated infix method
           }
         }
 
@@ -76,7 +72,6 @@ class ComparableMatchersTest : FreeSpec() {
           forAll(arrayOf(Pair(cp, cz), Pair(cz, cn))) {
             it.first shouldBe gt(it.second)
             it.first should beGreaterThan(it.second)
-            it.first should be gt it.second // Deprecated infix method
           }
         }
 
@@ -84,7 +79,6 @@ class ComparableMatchersTest : FreeSpec() {
           forAll(arrayOf(cn, cz, cp)) {
             shouldThrow<AssertionError> { it shouldBe gt(it) }
             shouldThrow<AssertionError> { it should beGreaterThan(it) }
-            shouldThrow<AssertionError> { it should be gt it } // Deprecated infix method
           }
         }
 
@@ -92,7 +86,6 @@ class ComparableMatchersTest : FreeSpec() {
           forAll(arrayOf(Pair(cn, cz), Pair(cz, cp))) {
             shouldThrow<AssertionError> { it.first shouldBe gt(it.second) }
             shouldThrow<AssertionError> { it.first should beGreaterThan(it.second) }
-            shouldThrow<AssertionError> { it.first should be gt it.second } // Deprecated infix method
           }
         }
 
@@ -104,7 +97,6 @@ class ComparableMatchersTest : FreeSpec() {
           forAll(arrayOf(Pair(cp, cp), Pair(cp, cz), Pair(cz, cz), Pair(cz, cn), Pair(cn, cn))) {
             it.first shouldBe gte(it.second)
             it.first should beGreaterThanOrEqualTo(it.second)
-            it.first should be gte it.second // Deprecated infix method
           }
         }
 
@@ -112,7 +104,6 @@ class ComparableMatchersTest : FreeSpec() {
           forAll(arrayOf(Pair(cn, cz), Pair(cz, cp))) {
             shouldThrow<AssertionError> { it.first shouldBe gte(it.second) }
             shouldThrow<AssertionError> { it.first should beGreaterThanOrEqualTo(it.second) }
-            shouldThrow<AssertionError> { it.first should be gte it.second } // Deprecated infix method
           }
         }
 


### PR DESCRIPTION
* Fixed `Matchers.kt` removing `interface Matchers` https://github.com/kotlintest/kotlintest/issues/132
* **Removed Deprecated** methods at `ComparableMatchers.kt`. Reason: version 2.0 should not contain deprecated methods. In addiction, `MatcherBuilder` no longer exists.
