### PR TITLE
Updated Kotlin to stable version 1.1.1 removing unneeded eap reposito…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,7 @@
 buildscript {
-    ext.kotlin_version = '1.1.0-rc-91'
+    ext.kotlin_version = '1.1.1'
     repositories {
         mavenCentral()
-        maven {
-            url "http://dl.bintray.com/kotlin/kotlin-eap-1.1"
-        }
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
@@ -27,9 +24,6 @@ apply plugin: 'signing'
 
 repositories {
     mavenCentral()
-    maven {
-        url "http://dl.bintray.com/kotlin/kotlin-eap-1.1"
-    }
 }
 
 task javadocJar(type: Jar) {
@@ -104,7 +98,4 @@ uploadArchives {
             }
         }
     }
-}
-sourceSets {
-    main.java.srcDirs += 'src/main/kotlin'
 }


### PR DESCRIPTION
…ries. Also removed unneeded sourceSets declaration.

Using kotlintest is requiring to use eap repositories which should not be needed now that Kotlin 1.1 is stable. Could you generate a new version of kotlintest with this so it can be used without issues in Kotlin 1.1 projects?