### PR TITLE
Improvement for TypeMatchers.beOfType

### DIFF
--- a/src/main/kotlin/io/kotlintest/matchers/TypeMatchers.kt
+++ b/src/main/kotlin/io/kotlintest/matchers/TypeMatchers.kt
@@ -13,10 +13,10 @@ fun <T> beTheSameInstanceAs(ref: T): Matcher<T> = object : Matcher<T> {
   override fun test(value: T) = Result(value === ref, "$value should be the same reference as $ref")
 }
 
-inline fun <reified T : Any> beOfType() = object : Matcher<T> {
+inline fun <reified T : Any> beOfType() = object : Matcher<Any> {
 
-  val exceptionClassName = T::class.qualifiedName
+  val className = T::class.qualifiedName
 
-  override fun test(value: T) =
-      Result(value.javaClass == T::class.java, "$value should be of type $exceptionClassName")
+  override fun test(value: Any) =
+      Result(value.javaClass == T::class.java, "$value should be of type $className")
 }

--- a/src/test/kotlin/io/kotlintest/matchers/TypeMatchersTest.kt
+++ b/src/test/kotlin/io/kotlintest/matchers/TypeMatchersTest.kt
@@ -1,23 +1,45 @@
 package io.kotlintest.matchers
 
 import io.kotlintest.specs.WordSpec
+import java.util.LinkedList
+import java.util.ArrayList
 
 class TypeMatchersTest : WordSpec() {
 
   init {
 
     "beInstanceOf" should {
-      "should test values of are of the required type" {
-        "a" should beOfType<String>()
+      "test that value is assignable to class" {
+        val arrayList : List<Int> = arrayListOf(1,2,3)
+
+        arrayList should beInstanceOf(ArrayList::class)
+
+        arrayList should beInstanceOf(List::class)
+
         shouldThrow<AssertionError> {
-          // 3 is not a number it is an Int
-          3 should beOfType<Number>()
+          arrayList should beInstanceOf(LinkedList::class)
+        }
+      }
+    }
+
+    "beOfType" should {
+      "test that value have exactly the same type" {
+        val arrayList : List<Int> = arrayListOf(1,2,3)
+
+        arrayList should beOfType<ArrayList<Int>>()
+
+        shouldThrow<AssertionError> {
+          arrayList should beOfType<LinkedList<Int>>()
+        }
+
+        shouldThrow<AssertionError> {
+          arrayList should beOfType<List<Int>>()
         }
       }
     }
 
     "TypeMatchers.theSameInstanceAs" should {
-      "should test that references are equal" {
+      "test that references are equal" {
         val b = listOf(1, 2, 3)
         val a = b
         val c = listOf(1, 2, 3)
@@ -31,7 +53,7 @@ class TypeMatchersTest : WordSpec() {
     }
 
     "beTheSameInstanceAs" should {
-      "should test that references are equal" {
+      "test that references are equal" {
         val b = listOf(1, 2, 3)
         val a = b
         val c = listOf(1, 2, 3)


### PR DESCRIPTION
In current implementation, given the following hierarchy of classes:

```kotlin
open class Base

class Derived : Base()
```

It's possible to write such code:

```kotlin
val d = Derived() 
d should beOfType<Derived>()
d shouldNot beOfType<Base>()
```

but compiler would complain, if you write:

```kotlin
val d : Base = Derived()
d should beOfType<Derived>()
```

Because it expects `Matcher<Base>` on the right-hand, or Matcher for any supertype to make automatic up-cast for `d`. It makes impossible to test, for example, factory methods. This PR addresses this issue.

Also, I've noticed that `"TypeMatchers.theSameInstanceAs"` and `"beTheSameInstanceAs"` are the same tests. Was it made intentionally or by mistake?
