### PR TITLE
Change shouldBe/shouldEqual error text to a format that IntelliJ displays more nicely.

### DIFF
--- a/src/main/kotlin/io/kotlintest/matchers/Matchers.kt
+++ b/src/main/kotlin/io/kotlintest/matchers/Matchers.kt
@@ -3,7 +3,7 @@ package io.kotlintest.matchers
 import org.junit.ComparisonFailure
 
 fun <T> equalityMatcher(expected: T) = object : Matcher<T> {
-  override fun test(value: T): Result = Result(expected == value, "$expected should equal $value")
+  override fun test(value: T): Result = Result(expected == value, equalsErrorMessage(expected, value))
 }
 
 fun fail(msg: String): Nothing = throw AssertionError(msg)
@@ -17,28 +17,38 @@ infix fun String.shouldBe(other: String) {
 }
 
 infix fun BooleanArray.shouldBe(other: BooleanArray): Unit {
-  if (this.toList() != other.toList())
-    throw AssertionError("Array not equal: $this != $other")
+  val expected = other.toList()
+  val actual = this.toList()
+  if (actual != expected)
+    throw equalsError(expected, actual)
 }
 
 infix fun IntArray.shouldBe(other: IntArray): Unit {
-  if (this.toList() != other.toList())
-    throw AssertionError("Array not equal: $this != $other")
+  val expected = other.toList()
+  val actual = this.toList()
+  if (actual != expected)
+    throw equalsError(expected, actual)
 }
 
 infix fun DoubleArray.shouldBe(other: DoubleArray): Unit {
-  if (this.toList() != other.toList())
-    throw AssertionError("Array not equal: $this != $other")
+  val expected = other.toList()
+  val actual = this.toList()
+  if (actual != expected)
+    throw equalsError(expected, actual)
 }
 
 infix fun LongArray.shouldBe(other: LongArray): Unit {
-  if (this.toList() != other.toList())
-    throw AssertionError("Array not equal: $this != $other")
+  val expected = other.toList()
+  val actual = this.toList()
+  if (actual != expected)
+    throw equalsError(expected, actual)
 }
 
 infix fun <T> Array<T>.shouldBe(other: Array<T>): Unit {
-  if (this.toList() != other.toList())
-    throw AssertionError("Array not equal: $this != $other")
+  val expected = other.toList()
+  val actual = this.toList()
+  if (actual != expected)
+    throw equalsError(expected, actual)
 }
 
 infix fun <T> T.shouldHave(matcher: Matcher<T>) = should(matcher)
@@ -48,9 +58,9 @@ infix fun <T> T.shouldEqual(any: Any?): Unit {
     is Matcher<*> -> should(any as Matcher<T>)
     else -> {
       if (this == null && any != null)
-        throw AssertionError(this.toString() + " did not equal $any")
+        throw equalsError(any, this)
       if (this != any)
-        throw AssertionError(this.toString() + " did not equal $any")
+        throw equalsError(any, this)
     }
   }
 }
@@ -75,3 +85,6 @@ infix fun <T> T.shouldNot(matcher: Matcher<T>): Unit {
   if (result.passed)
     throw AssertionError("Test passed which should have failed: " + result.message)
 }
+
+private fun equalsError(expected: Any?, actual: Any?) = AssertionError(equalsErrorMessage(expected, actual))
+private fun equalsErrorMessage(expected: Any?, actual: Any?) = "expected: $expected but was: $actual"


### PR DESCRIPTION
#179 