### PR TITLE
Invert expected and actual values for String comparison error message

### DIFF
--- a/src/main/kotlin/io/kotlintest/matchers/Matchers.kt
+++ b/src/main/kotlin/io/kotlintest/matchers/Matchers.kt
@@ -12,7 +12,7 @@ infix fun Double.shouldBe(other: Double): Unit = should(ToleranceMatcher(other, 
 
 infix fun String.shouldBe(other: String) {
   if (this != other) {
-    throw ComparisonFailure("", this, other)
+    throw ComparisonFailure("", other, this)
   }
 }
 

--- a/src/test/kotlin/io/kotlintest/matchers/StringMatchersTest.kt
+++ b/src/test/kotlin/io/kotlintest/matchers/StringMatchersTest.kt
@@ -10,7 +10,7 @@ class StringMatchersTest : FreeSpec() {
       "should show divergence in error message" {
         shouldThrow<ComparisonFailure> {
           "la tour eiffel" shouldBe "la tour tower london"
-        }.message shouldBe "expected:<la tour [eiffel]> but was:<la tour [tower london]>"
+        }.message shouldBe "expected:<la tour [tower london]> but was:<la tour [eiffel]>"
       }
     }
 


### PR DESCRIPTION
When comparing String values expected and actual values are inverted in comparison error message.
```java
    "test" {
        "actual" shouldBe "expected"
    }
```
When running test:
```
org.junit.ComparisonFailure: 
Expected :actual
Actual   :expected
```
