### PR TITLE
doc typo fix: add closing double-quote

### DIFF
--- a/doc/reference.md
+++ b/doc/reference.md
@@ -476,7 +476,7 @@ An interceptor would look like this:
 val myTestCaseInterceptor: (TestCaseContext, () -> Unit) -> Unit = { context, testCase ->
   println("before")
   testCase() // Don't forget to call testCase()!
-  println("after)
+  println("after")
 }
 ```
 


### PR DESCRIPTION
Noticed that there was a tiny typo in the docs, fixing it.