### PR TITLE
Improve "eventually" syntax to allow passing custom Exception type

### DIFF
--- a/src/main/kotlin/io/kotlintest/Eventually.kt
+++ b/src/main/kotlin/io/kotlintest/Eventually.kt
@@ -1,13 +1,21 @@
 package io.kotlintest
 
-fun <T>eventually(duration: Duration, f: () -> T): T {
+import java.lang.Exception
+
+fun <T>eventually(duration: Duration, f: () -> T): T = eventually(duration, Exception::class.java, f)
+
+fun <T, E : Throwable>eventually(duration: Duration, exceptionClass: Class<E>, f: () -> T): T {
   val end = System.nanoTime() + duration.nanoseconds
   var times = 0
   while (System.nanoTime() < end) {
     try {
       return f()
-    } catch (e: Exception) {
-      // ignore and proceed
+    } catch (e: Throwable) {
+      if(!exceptionClass.isAssignableFrom(e.javaClass)) {
+        // Not the kind of exception we were prepared to tolerate
+        throw e
+      }
+      // else ignore and continue
     }
     times++
   }

--- a/src/test/kotlin/io/kotlintest/EventuallyTest.kt
+++ b/src/test/kotlin/io/kotlintest/EventuallyTest.kt
@@ -3,6 +3,7 @@ package io.kotlintest
 import io.kotlintest.matchers.shouldBe
 import io.kotlintest.specs.WordSpec
 import io.kotlintest.matchers.shouldThrow
+import java.io.IOException
 
 class EventuallyTest : WordSpec() {
 
@@ -32,6 +33,20 @@ class EventuallyTest : WordSpec() {
           1
         }
         result shouldBe 1
+      }
+      "pass tests that completed within the time allowed, custom exception"  {
+        val end = System.currentTimeMillis() + 2000
+        eventually(5.days, AssertionError::class.java) {
+          if (System.currentTimeMillis() < end)
+            assert(false)
+        }
+      }
+      "fail tests throw unexpected exception type"  {
+        shouldThrow<KotlinNullPointerException> {
+          eventually(2.seconds, IOException::class.java) {
+            (null as String?)!!.length
+          }
+        }
       }
     }
   }

--- a/src/test/kotlin/io/kotlintest/EventuallyTest.kt
+++ b/src/test/kotlin/io/kotlintest/EventuallyTest.kt
@@ -3,6 +3,7 @@ package io.kotlintest
 import io.kotlintest.matchers.shouldBe
 import io.kotlintest.specs.WordSpec
 import io.kotlintest.matchers.shouldThrow
+import java.io.FileNotFoundException
 import java.io.IOException
 
 class EventuallyTest : WordSpec() {
@@ -46,6 +47,13 @@ class EventuallyTest : WordSpec() {
           eventually(2.seconds, IOException::class.java) {
             (null as String?)!!.length
           }
+        }
+      }
+      "pass tests that throws FileNotFoundException for some time"  {
+        val end = System.currentTimeMillis() + 2000
+        eventually(5.days) {
+          if (System.currentTimeMillis() < end)
+            throw FileNotFoundException("foo")
         }
       }
     }


### PR DESCRIPTION
This is useful when it is know that the block of code can fail with "AssertionError" for some time.
AssertionError is not of type Exception so old implementation is limiting in this regard.