### PR TITLE
Improvements in property-based testing.

### DIFF
--- a/doc/reference.md
+++ b/doc/reference.md
@@ -233,6 +233,25 @@ class PropertyExample: StringSpec() {
 }
 ```
 
+You can also specify the number of times a test is going to be run. Here is the same test but ran 2300 times.
+
+```kotlin
+import io.kotlintest.properties.*
+import io.kotlintest.specs.StringSpec
+
+class PropertyExample: StringSpec() {
+  init {
+
+    "String size" {
+      forAll(2300) { a: String, b: String ->
+        (a + b).length == a.length + b.length
+      }
+    }
+
+  }
+}
+```
+
 There are generators for all the common types - String, Ints, Sets, etc. If you need to generate custom types
 then you can simply specify the generator manually (and write your own). For example here is the same test again but
 with the generators specified.

--- a/src/main/kotlin/io/kotlintest/properties/PropertyTesting.kt
+++ b/src/main/kotlin/io/kotlintest/properties/PropertyTesting.kt
@@ -4,12 +4,23 @@ inline fun <reified A> forAll(noinline fn: (a: A) -> Boolean): Unit {
   forAll(Gen.default<A>(), fn)
 }
 
+inline fun <reified A> forAll(attempts: Int, noinline fn: (a: A) -> Boolean): Unit {
+  forAll(attempts, Gen.default<A>(), fn)
+}
+
 fun <A> forAll(gena: Gen<A>, fn: (a: A) -> Boolean): Unit {
-  for (k in 0..1000) {
+  forAll(1000, gena, fn)
+}
+
+fun <A> forAll(attempts: Int, gena: Gen<A>, fn: (a: A) -> Boolean): Unit {
+  if (attempts <= 0)
+    throw IllegalArgumentException("Attempts should be a positive number")
+
+  for (k in 1..attempts) {
     val a = gena.generate()
     val passed = fn(a)
     if (!passed) {
-      throw AssertionError("Property failed for\n$a")
+      throw AssertionError("Property failed for\n$a\nafter $k attempts")
     }
   }
 }
@@ -18,15 +29,31 @@ inline fun <reified A, reified B> forAll(noinline fn: (a: A, b: B) -> Boolean): 
   forAll(Gen.default<A>(), Gen.default<B>(), fn)
 }
 
+
+inline fun <reified A, reified B> forAll(attempts: Int, noinline fn: (a: A, b: B) -> Boolean): Unit {
+  forAll(attempts, Gen.default<A>(), Gen.default<B>(), fn)
+}
+
 fun <A, B> forAll(gena: Gen<A>, genb: Gen<B>, fn: (a: A, b: B) -> Boolean): Unit {
-  for (k in 0..1000) {
+  forAll(1000, gena, genb, fn)
+}
+
+fun <A, B> forAll(attempts: Int, gena: Gen<A>, genb: Gen<B>, fn: (a: A, b: B) -> Boolean): Unit {
+  if (attempts <= 0)
+    throw IllegalArgumentException("The number of attempts should be a positive number")
+
+  for (k in 1..attempts) {
     val a = gena.generate()
     val b = genb.generate()
     val passed = fn(a, b)
     if (!passed) {
-      throw AssertionError("Property failed for\n$a\n$b)")
+      throw AssertionError("Property failed for\n$a\n$b\nafter $k attempts")
     }
   }
+}
+
+inline fun <reified A, reified B, reified C> forAll(attempts: Int, noinline fn: (a: A, b: B, c: C) -> Boolean): Unit {
+  forAll(attempts, Gen.default<A>(), Gen.default<B>(), Gen.default<C>(), fn)
 }
 
 inline fun <reified A, reified B, reified C> forAll(noinline fn: (a: A, b: B, c: C) -> Boolean): Unit {
@@ -34,13 +61,20 @@ inline fun <reified A, reified B, reified C> forAll(noinline fn: (a: A, b: B, c:
 }
 
 fun <A, B, C> forAll(gena: Gen<A>, genb: Gen<B>, genc: Gen<C>, fn: (a: A, b: B, c: C) -> Boolean): Unit {
-  for (k in 0..1000) {
+  forAll(1000, gena, genb, genc, fn)
+}
+
+fun <A, B, C> forAll(attempts: Int, gena: Gen<A>, genb: Gen<B>, genc: Gen<C>, fn: (a: A, b: B, c: C) -> Boolean): Unit {
+  if (attempts <= 0)
+    throw IllegalArgumentException("Attempts should be a positive number")
+
+  for (k in 1..attempts) {
     val a = gena.generate()
     val b = genb.generate()
     val c = genc.generate()
     val passed = fn(a, b, c)
     if (!passed) {
-      throw AssertionError("Property failed for\n$a\n$b\n$c)")
+      throw AssertionError("Property failed for\n$a\n$b\n$c\nafter $k attempts")
     }
   }
 }
@@ -49,15 +83,26 @@ inline fun <reified A, reified B, reified C, reified D> forAll(noinline fn: (a: 
   forAll(Gen.default<A>(), Gen.default<B>(), Gen.default<C>(), Gen.default<D>(), fn)
 }
 
+inline fun <reified A, reified B, reified C, reified D> forAll(attempts: Int, noinline fn: (a: A, b: B, c: C, D) -> Boolean): Unit {
+  forAll(attempts, Gen.default<A>(), Gen.default<B>(), Gen.default<C>(), Gen.default<D>(), fn)
+}
+
 fun <A, B, C, D> forAll(gena: Gen<A>, genb: Gen<B>, genc: Gen<C>, gend: Gen<D>, fn: (a: A, b: B, c: C, d: D) -> Boolean): Unit {
-  for (k in 0..1000) {
+  forAll(1000, gena, genb, genc, gend, fn)
+}
+
+fun <A, B, C, D> forAll(attempts: Int, gena: Gen<A>, genb: Gen<B>, genc: Gen<C>, gend: Gen<D>, fn: (a: A, b: B, c: C, d: D) -> Boolean): Unit {
+  if (attempts <= 0)
+    throw IllegalArgumentException("Attempts should be a positive number")
+
+  for (k in 1..attempts) {
     val a = gena.generate()
     val b = genb.generate()
     val c = genc.generate()
     val d = gend.generate()
     val passed = fn(a, b, c, d)
     if (!passed) {
-      throw AssertionError("Property failed for \n$a\n$b\n$c\n$d)")
+      throw AssertionError("Property failed for \n$a\n$b\n$c\n$d\nafter $k attempts")
     }
   }
 }
@@ -66,8 +111,18 @@ inline fun <reified A, reified B, reified C, reified D, reified E> forAll(noinli
   forAll(Gen.default<A>(), Gen.default<B>(), Gen.default<C>(), Gen.default<D>(), Gen.default<E>(), fn)
 }
 
+inline fun <reified A, reified B, reified C, reified D, reified E> forAll(attempts: Int, noinline fn: (a: A, b: B, c: C, d: D, e: E) -> Boolean): Unit {
+  forAll(attempts, Gen.default<A>(), Gen.default<B>(), Gen.default<C>(), Gen.default<D>(), Gen.default<E>(), fn)
+}
+
 fun <A, B, C, D, E> forAll(gena: Gen<A>, genb: Gen<B>, genc: Gen<C>, gend: Gen<D>, gene: Gen<E>, fn: (a: A, b: B, c: C, d: D, e: E) -> Boolean): Unit {
-  for (k in 0..1000) {
+  forAll(1000, gena, genb, genc, gend, gene, fn)
+}
+fun <A, B, C, D, E> forAll(attempts: Int, gena: Gen<A>, genb: Gen<B>, genc: Gen<C>, gend: Gen<D>, gene: Gen<E>, fn: (a: A, b: B, c: C, d: D, e: E) -> Boolean): Unit {
+  if (attempts <= 0)
+    throw IllegalArgumentException("Attempts should be a positive number")
+
+  for (k in 1..attempts) {
     val a = gena.generate()
     val b = genb.generate()
     val c = genc.generate()
@@ -75,7 +130,7 @@ fun <A, B, C, D, E> forAll(gena: Gen<A>, genb: Gen<B>, genc: Gen<C>, gend: Gen<D
     val e = gene.generate()
     val passed = fn(a, b, c, d, e)
     if (!passed) {
-      throw AssertionError("Property failed for \n$a\n$b\n$c\n$d\n$e")
+      throw AssertionError("Property failed for \n$a\n$b\n$c\n$d\n$e\nafter $k attempts")
     }
   }
 }
@@ -84,8 +139,19 @@ inline fun <reified A, reified B, reified C, reified D, reified E, reified F> fo
   forAll(Gen.default<A>(), Gen.default<B>(), Gen.default<C>(), Gen.default<D>(), Gen.default<E>(), Gen.default<F>(), fn)
 }
 
+inline fun <reified A, reified B, reified C, reified D, reified E, reified F> forAll(attempts: Int, noinline fn: (a: A, b: B, c: C, d: D, e: E, f: F) -> Boolean): Unit {
+  forAll(attempts, Gen.default<A>(), Gen.default<B>(), Gen.default<C>(), Gen.default<D>(), Gen.default<E>(), Gen.default<F>(), fn)
+}
+
 fun <A, B, C, D, E, F> forAll(gena: Gen<A>, genb: Gen<B>, genc: Gen<C>, gend: Gen<D>, gene: Gen<E>, genf: Gen<F>, fn: (a: A, b: B, c: C, d: D, e: E, f: F) -> Boolean): Unit {
-  for (k in 0..1000) {
+  forAll(1000, gena, genb, genc, gend, gene, genf, fn)
+}
+
+fun <A, B, C, D, E, F> forAll(attempts: Int, gena: Gen<A>, genb: Gen<B>, genc: Gen<C>, gend: Gen<D>, gene: Gen<E>, genf: Gen<F>, fn: (a: A, b: B, c: C, d: D, e: E, f: F) -> Boolean): Unit {
+  if (attempts <= 0)
+    throw IllegalArgumentException("Attempts should be a positive number")
+
+  for (k in 1..attempts) {
     val a = gena.generate()
     val b = genb.generate()
     val c = genc.generate()
@@ -94,7 +160,7 @@ fun <A, B, C, D, E, F> forAll(gena: Gen<A>, genb: Gen<B>, genc: Gen<C>, gend: Ge
     val f = genf.generate()
     val passed = fn(a, b, c, d, e, f)
     if (!passed) {
-      throw AssertionError("Property failed for \n$a\n$b\n$c\n$d\n$e\n$f")
+      throw AssertionError("Property failed for \n$a\n$b\n$c\n$d\n$e\n$f\nafter $k attempts")
     }
   }
 }

--- a/src/main/kotlin/io/kotlintest/properties/PropertyTesting.kt
+++ b/src/main/kotlin/io/kotlintest/properties/PropertyTesting.kt
@@ -193,13 +193,23 @@ inline fun <reified A, reified B> forNone(noinline fn: (a: A, b: B) -> Boolean):
   forNone(Gen.default<A>(), Gen.default<B>(), fn)
 }
 
+inline fun <reified A, reified B> forNone(attempts: Int, noinline fn: (a: A, b: B) -> Boolean): Unit {
+  forNone(attempts, Gen.default<A>(), Gen.default<B>(), fn)
+}
+
 fun <A, B> forNone(gena: Gen<A>, genb: Gen<B>, fn: (a: A, b: B) -> Boolean): Unit {
-  for (k in 0..1000) {
+  forNone(1000, gena, genb, fn)
+}
+
+fun <A, B> forNone(attempts: Int, gena: Gen<A>, genb: Gen<B>, fn: (a: A, b: B) -> Boolean): Unit {
+  checkNumberOfAttemptsIsAPositiveNumber(attempts)
+
+  for (k in 1..attempts) {
     val a = gena.generate()
     val b = genb.generate()
     val passed = fn(a, b)
     if (passed) {
-      throw AssertionError("Property passed for\n$a\n$b)")
+      throw AssertionError("Property passed for\n$a\n$b\nafter $k attempts")
     }
   }
 }
@@ -208,14 +218,24 @@ inline fun <reified A, reified B, reified C> forNone(noinline fn: (a: A, b: B, c
   forNone(Gen.default<A>(), Gen.default<B>(), Gen.default<C>(), fn)
 }
 
+inline fun <reified A, reified B, reified C> forNone(attempts: Int, noinline fn: (a: A, b: B, c: C) -> Boolean): Unit {
+  forNone(attempts, Gen.default<A>(), Gen.default<B>(), Gen.default<C>(), fn)
+}
+
 fun <A, B, C> forNone(gena: Gen<A>, genb: Gen<B>, genc: Gen<C>, fn: (a: A, b: B, c: C) -> Boolean): Unit {
-  for (k in 0..1000) {
+  forNone(1000, gena, genb, genc, fn)
+}
+
+fun <A, B, C> forNone(attempts: Int, gena: Gen<A>, genb: Gen<B>, genc: Gen<C>, fn: (a: A, b: B, c: C) -> Boolean): Unit {
+  checkNumberOfAttemptsIsAPositiveNumber(attempts)
+
+  for (k in 1..attempts) {
     val a = gena.generate()
     val b = genb.generate()
     val c = genc.generate()
     val passed = fn(a, b, c)
     if (passed) {
-      throw AssertionError("Property passed for\n$a\n$b\n$c)")
+      throw AssertionError("Property passed for\n$a\n$b\n$c\nafter $k attempts")
     }
   }
 }

--- a/src/main/kotlin/io/kotlintest/properties/PropertyTesting.kt
+++ b/src/main/kotlin/io/kotlintest/properties/PropertyTesting.kt
@@ -240,19 +240,29 @@ fun <A, B, C> forNone(attempts: Int, gena: Gen<A>, genb: Gen<B>, genc: Gen<C>, f
   }
 }
 
+inline fun <reified A, reified B, reified C, reified D> forNone(attempts: Int, noinline fn: (a: A, b: B, c: C, D) -> Boolean): Unit {
+  forNone(attempts, Gen.default<A>(), Gen.default<B>(), Gen.default<C>(), Gen.default<D>(), fn)
+}
+
 inline fun <reified A, reified B, reified C, reified D> forNone(noinline fn: (a: A, b: B, c: C, D) -> Boolean): Unit {
   forNone(Gen.default<A>(), Gen.default<B>(), Gen.default<C>(), Gen.default<D>(), fn)
 }
 
 fun <A, B, C, D> forNone(gena: Gen<A>, genb: Gen<B>, genc: Gen<C>, gend: Gen<D>, fn: (a: A, b: B, c: C, d: D) -> Boolean): Unit {
-  for (k in 0..1000) {
+  forNone(1000, gena, genb, genc, gend, fn)
+}
+
+fun <A, B, C, D> forNone(attempts: Int, gena: Gen<A>, genb: Gen<B>, genc: Gen<C>, gend: Gen<D>, fn: (a: A, b: B, c: C, d: D) -> Boolean): Unit {
+  checkNumberOfAttemptsIsAPositiveNumber(attempts)
+
+  for (k in 1..attempts) {
     val a = gena.generate()
     val b = genb.generate()
     val c = genc.generate()
     val d = gend.generate()
     val passed = fn(a, b, c, d)
     if (passed) {
-      throw AssertionError("Property passed for \n$a\n$b\n$c\n$d)")
+      throw AssertionError("Property passed for \n$a\n$b\n$c\n$d\nafter $k attempts")
     }
   }
 }

--- a/src/main/kotlin/io/kotlintest/properties/PropertyTesting.kt
+++ b/src/main/kotlin/io/kotlintest/properties/PropertyTesting.kt
@@ -13,8 +13,7 @@ fun <A> forAll(gena: Gen<A>, fn: (a: A) -> Boolean): Unit {
 }
 
 fun <A> forAll(attempts: Int, gena: Gen<A>, fn: (a: A) -> Boolean): Unit {
-  if (attempts <= 0)
-    throw IllegalArgumentException("Attempts should be a positive number")
+  checkNumberOfAttemptsIsAPositiveNumber(attempts)
 
   for (k in 1..attempts) {
     val a = gena.generate()
@@ -65,8 +64,7 @@ fun <A, B, C> forAll(gena: Gen<A>, genb: Gen<B>, genc: Gen<C>, fn: (a: A, b: B, 
 }
 
 fun <A, B, C> forAll(attempts: Int, gena: Gen<A>, genb: Gen<B>, genc: Gen<C>, fn: (a: A, b: B, c: C) -> Boolean): Unit {
-  if (attempts <= 0)
-    throw IllegalArgumentException("Attempts should be a positive number")
+  checkNumberOfAttemptsIsAPositiveNumber(attempts)
 
   for (k in 1..attempts) {
     val a = gena.generate()
@@ -92,8 +90,7 @@ fun <A, B, C, D> forAll(gena: Gen<A>, genb: Gen<B>, genc: Gen<C>, gend: Gen<D>, 
 }
 
 fun <A, B, C, D> forAll(attempts: Int, gena: Gen<A>, genb: Gen<B>, genc: Gen<C>, gend: Gen<D>, fn: (a: A, b: B, c: C, d: D) -> Boolean): Unit {
-  if (attempts <= 0)
-    throw IllegalArgumentException("Attempts should be a positive number")
+  checkNumberOfAttemptsIsAPositiveNumber(attempts)
 
   for (k in 1..attempts) {
     val a = gena.generate()
@@ -119,8 +116,7 @@ fun <A, B, C, D, E> forAll(gena: Gen<A>, genb: Gen<B>, genc: Gen<C>, gend: Gen<D
   forAll(1000, gena, genb, genc, gend, gene, fn)
 }
 fun <A, B, C, D, E> forAll(attempts: Int, gena: Gen<A>, genb: Gen<B>, genc: Gen<C>, gend: Gen<D>, gene: Gen<E>, fn: (a: A, b: B, c: C, d: D, e: E) -> Boolean): Unit {
-  if (attempts <= 0)
-    throw IllegalArgumentException("Attempts should be a positive number")
+  checkNumberOfAttemptsIsAPositiveNumber(attempts)
 
   for (k in 1..attempts) {
     val a = gena.generate()
@@ -148,8 +144,7 @@ fun <A, B, C, D, E, F> forAll(gena: Gen<A>, genb: Gen<B>, genc: Gen<C>, gend: Ge
 }
 
 fun <A, B, C, D, E, F> forAll(attempts: Int, gena: Gen<A>, genb: Gen<B>, genc: Gen<C>, gend: Gen<D>, gene: Gen<E>, genf: Gen<F>, fn: (a: A, b: B, c: C, d: D, e: E, f: F) -> Boolean): Unit {
-  if (attempts <= 0)
-    throw IllegalArgumentException("Attempts should be a positive number")
+  checkNumberOfAttemptsIsAPositiveNumber(attempts)
 
   for (k in 1..attempts) {
     val a = gena.generate()
@@ -165,16 +160,31 @@ fun <A, B, C, D, E, F> forAll(attempts: Int, gena: Gen<A>, genb: Gen<B>, genc: G
   }
 }
 
+private fun checkNumberOfAttemptsIsAPositiveNumber(attempts: Int) {
+  if (attempts <= 0)
+    throw IllegalArgumentException("Attempts should be a positive number")
+}
+
 inline fun <reified A> forNone(noinline fn: (a: A) -> Boolean): Unit {
   forNone(Gen.default<A>(), fn)
 }
 
+inline fun <reified A> forNone(attempts: Int, noinline fn: (a: A) -> Boolean): Unit {
+  forNone(attempts, Gen.default<A>(), fn)
+}
+
 fun <A> forNone(gena: Gen<A>, fn: (a: A) -> Boolean): Unit {
-  for (k in 0..1000) {
+  forNone(1000, gena, fn)
+}
+
+fun <A> forNone(attempts: Int, gena: Gen<A>, fn: (a: A) -> Boolean): Unit {
+  checkNumberOfAttemptsIsAPositiveNumber(attempts)
+
+  for (k in 1..attempts) {
     val a = gena.generate()
     val passed = fn(a)
     if (passed) {
-      throw AssertionError("Property passed for\n$a")
+      throw AssertionError("Property passed for\n$a\nafter $k attempts")
     }
   }
 }

--- a/src/main/kotlin/io/kotlintest/properties/PropertyTesting.kt
+++ b/src/main/kotlin/io/kotlintest/properties/PropertyTesting.kt
@@ -267,12 +267,20 @@ fun <A, B, C, D> forNone(attempts: Int, gena: Gen<A>, genb: Gen<B>, genc: Gen<C>
   }
 }
 
+inline fun <reified A, reified B, reified C, reified D, reified E> forNone(attempts: Int, noinline fn: (a: A, b: B, c: C, d: D, e: E) -> Boolean): Unit {
+  forNone(attempts, Gen.default<A>(), Gen.default<B>(), Gen.default<C>(), Gen.default<D>(), Gen.default<E>(), fn)
+}
 inline fun <reified A, reified B, reified C, reified D, reified E> forNone(noinline fn: (a: A, b: B, c: C, d: D, e: E) -> Boolean): Unit {
   forNone(Gen.default<A>(), Gen.default<B>(), Gen.default<C>(), Gen.default<D>(), Gen.default<E>(), fn)
 }
 
 fun <A, B, C, D, E> forNone(gena: Gen<A>, genb: Gen<B>, genc: Gen<C>, gend: Gen<D>, gene: Gen<E>, fn: (a: A, b: B, c: C, d: D, e: E) -> Boolean): Unit {
-  for (k in 0..1000) {
+  forNone(1000, gena, genb, genc, gend, gene, fn)
+}
+fun <A, B, C, D, E> forNone(attempts: Int, gena: Gen<A>, genb: Gen<B>, genc: Gen<C>, gend: Gen<D>, gene: Gen<E>, fn: (a: A, b: B, c: C, d: D, e: E) -> Boolean): Unit {
+  checkNumberOfAttemptsIsAPositiveNumber(attempts)
+
+  for (k in 1..attempts) {
     val a = gena.generate()
     val b = genb.generate()
     val c = genc.generate()
@@ -280,7 +288,7 @@ fun <A, B, C, D, E> forNone(gena: Gen<A>, genb: Gen<B>, genc: Gen<C>, gend: Gen<
     val e = gene.generate()
     val passed = fn(a, b, c, d, e)
     if (passed) {
-      throw AssertionError("Property passed for \n$a\n$b\n$c\n$d\n$e")
+      throw AssertionError("Property passed for \n$a\n$b\n$c\n$d\n$e\nafter $k attempts")
     }
   }
 }

--- a/src/main/kotlin/io/kotlintest/properties/PropertyTesting.kt
+++ b/src/main/kotlin/io/kotlintest/properties/PropertyTesting.kt
@@ -270,6 +270,7 @@ fun <A, B, C, D> forNone(attempts: Int, gena: Gen<A>, genb: Gen<B>, genc: Gen<C>
 inline fun <reified A, reified B, reified C, reified D, reified E> forNone(attempts: Int, noinline fn: (a: A, b: B, c: C, d: D, e: E) -> Boolean): Unit {
   forNone(attempts, Gen.default<A>(), Gen.default<B>(), Gen.default<C>(), Gen.default<D>(), Gen.default<E>(), fn)
 }
+
 inline fun <reified A, reified B, reified C, reified D, reified E> forNone(noinline fn: (a: A, b: B, c: C, d: D, e: E) -> Boolean): Unit {
   forNone(Gen.default<A>(), Gen.default<B>(), Gen.default<C>(), Gen.default<D>(), Gen.default<E>(), fn)
 }
@@ -277,6 +278,7 @@ inline fun <reified A, reified B, reified C, reified D, reified E> forNone(noinl
 fun <A, B, C, D, E> forNone(gena: Gen<A>, genb: Gen<B>, genc: Gen<C>, gend: Gen<D>, gene: Gen<E>, fn: (a: A, b: B, c: C, d: D, e: E) -> Boolean): Unit {
   forNone(1000, gena, genb, genc, gend, gene, fn)
 }
+
 fun <A, B, C, D, E> forNone(attempts: Int, gena: Gen<A>, genb: Gen<B>, genc: Gen<C>, gend: Gen<D>, gene: Gen<E>, fn: (a: A, b: B, c: C, d: D, e: E) -> Boolean): Unit {
   checkNumberOfAttemptsIsAPositiveNumber(attempts)
 
@@ -293,12 +295,22 @@ fun <A, B, C, D, E> forNone(attempts: Int, gena: Gen<A>, genb: Gen<B>, genc: Gen
   }
 }
 
+inline fun <reified A, reified B, reified C, reified D, reified E, reified F> forNone(attempts: Int, noinline fn: (a: A, b: B, c: C, d: D, e: E, f: F) -> Boolean): Unit {
+  forNone(attempts, Gen.default<A>(), Gen.default<B>(), Gen.default<C>(), Gen.default<D>(), Gen.default<E>(), Gen.default<F>(), fn)
+}
+
 inline fun <reified A, reified B, reified C, reified D, reified E, reified F> forNone(noinline fn: (a: A, b: B, c: C, d: D, e: E, f: F) -> Boolean): Unit {
   forNone(Gen.default<A>(), Gen.default<B>(), Gen.default<C>(), Gen.default<D>(), Gen.default<E>(), Gen.default<F>(), fn)
 }
 
 fun <A, B, C, D, E, F> forNone(gena: Gen<A>, genb: Gen<B>, genc: Gen<C>, gend: Gen<D>, gene: Gen<E>, genf: Gen<F>, fn: (a: A, b: B, c: C, d: D, e: E, f: F) -> Boolean): Unit {
-  for (k in 0..1000) {
+  forNone(1000, gena, genb, genc, gend, gene, genf, fn)
+}
+
+fun <A, B, C, D, E, F> forNone(attempts: Int, gena: Gen<A>, genb: Gen<B>, genc: Gen<C>, gend: Gen<D>, gene: Gen<E>, genf: Gen<F>, fn: (a: A, b: B, c: C, d: D, e: E, f: F) -> Boolean): Unit {
+  checkNumberOfAttemptsIsAPositiveNumber(attempts)
+
+  for (k in 1..attempts) {
     val a = gena.generate()
     val b = genb.generate()
     val c = genc.generate()
@@ -307,7 +319,7 @@ fun <A, B, C, D, E, F> forNone(gena: Gen<A>, genb: Gen<B>, genc: Gen<C>, gend: G
     val f = genf.generate()
     val passed = fn(a, b, c, d, e, f)
     if (passed) {
-      throw AssertionError("Property passed for \n$a\n$b\n$c\n$d\n$e\n$f")
+      throw AssertionError("Property passed for \n$a\n$b\n$c\n$d\n$e\n$f\nafter $k attempts")
     }
   }
 }

--- a/src/test/kotlin/io/kotlintest/properties/PropertyTestingTest.kt
+++ b/src/test/kotlin/io/kotlintest/properties/PropertyTestingTest.kt
@@ -1,20 +1,87 @@
 package io.kotlintest.properties
 
+import io.kotlintest.matchers.shouldBe
+import io.kotlintest.matchers.shouldThrow
 import io.kotlintest.specs.StringSpec
 
 class PropertyTestingTest : StringSpec() {
   init {
 
     "startsWith" {
+      var actualAttempts = 0
       forAll(Gen.string(), Gen.string(), { a, b ->
+        actualAttempts++
         (a + b).startsWith(a)
       })
+      actualAttempts shouldBe 1000
+    }
+
+    "endsWith a hundred times" {
+      var actualAttempts = 0
+      forAll(100, Gen.string(), Gen.string()) { a, b ->
+        actualAttempts++
+        (a + b).endsWith(b)
+      }
+      actualAttempts shouldBe 100
     }
 
     "size" {
+      var actualAttempts = 0
       forAll { a: String, b: String ->
+        actualAttempts++
         (a + b).length == a.length + b.length
       }
+      actualAttempts shouldBe 1000
+    }
+
+    "failure after 4 attempts" {
+      var element1 = ""
+      var element2 = ""
+      val exception =
+          shouldThrow<AssertionError> {
+            var attempts = 0
+            forAll(20, Gen.string(), Gen.string()) { a, b ->
+              element1 = a
+              element2 = b
+              attempts++
+              attempts < 4
+            }
+          }
+      exception.message shouldBe "Property failed for\n$element1\n$element2\nafter 4 attempts"
+    }
+
+    "failure after 50 attempts" {
+      var element1 = ""
+      var element2 = ""
+      val exception =
+          shouldThrow<AssertionError> {
+            var attempts = 0
+            forAll(200, Gen.string(), Gen.string()) { a, b ->
+              element1 = a
+              element2 = b
+              attempts++
+              attempts < 50
+            }
+          }
+      exception.message shouldBe "Property failed for\n$element1\n$element2\nafter 50 attempts"
+    }
+
+    "running for 0 attempts" {
+      val exception = shouldThrow<IllegalArgumentException> {
+        forAll(0, Gen.string(), Gen.string()) { a, b ->
+          (a + b).startsWith(a)
+        }
+      }
+      exception.message shouldBe "The number of attempts should be a positive number"
+    }
+
+    "running for -1 attempts" {
+      val exception = shouldThrow<IllegalArgumentException> {
+        forAll(-1, Gen.string(), Gen.string()) { a, b ->
+          (a + b).startsWith(a)
+        }
+      }
+      exception.message shouldBe "The number of attempts should be a positive number"
     }
 
     "explicitGenerators" {
@@ -32,6 +99,115 @@ class PropertyTestingTest : StringSpec() {
       }
     }
 
+    "forAll single generator explicit 1000 attempts" {
+      var attempts = 0
+      forAll(Gen.int()) { a ->
+        attempts++
+        Math.abs(a) > 0
+      }
+
+      attempts shouldBe 1000
+    }
+
+    "forAll single generator explicit 20 attempts" {
+      var attempts = 0
+      forAll(20, Gen.int()) { a ->
+        attempts++
+        a * 2 == 2 * a
+      }
+      attempts shouldBe 20
+    }
+
+    "forAll single gnerator explicit 500 atempts" {
+      var attempts = 0
+      forAll(500, Gen.positiveIntegers()) { a ->
+        attempts++
+        a + 2 > a
+      }
+      attempts shouldBe 500
+    }
+
+    "forAll one explicit generator: test fails after second attempt" {
+      var attempts = 0
+      var element = 0.0
+      val exception = shouldThrow<AssertionError> {
+        forAll(4, Gen.double()) { a ->
+          attempts++
+          element = a
+          attempts < 2
+        }
+      }
+      exception.message shouldBe "Property failed for\n$element\nafter 2 attempts"
+    }
+
+    "forAll one explicit generator: test fails after 300 attempts" {
+      var attempts = 0
+      var element = ""
+      val exception = shouldThrow<AssertionError> {
+        forAll(350, Gen.string()) { s ->
+          element = s
+          attempts++
+          attempts < 300
+        }
+      }
+
+      exception.message shouldBe "Property failed for\n$element\nafter 300 attempts"
+    }
+
+    "forALl one explicit generator with 0 attempts" {
+      val exception = shouldThrow<IllegalArgumentException> {
+        forAll(0, Gen.long()) { a ->
+          a > a - 1
+        }
+      }
+      exception.message shouldBe "Attempts should be a positive number"
+    }
+
+    "forAll one explicit generator with -2 attempts" {
+      val exception = shouldThrow<IllegalArgumentException> {
+        forAll(-2, Gen.long()) { a ->
+          a > a - 1
+        }
+      }
+      exception.message shouldBe "Attempts should be a positive number"
+    }
+
+    "forAll one generator implicit 10 attempts" {
+      var attempts = 0
+      forAll(10) { a: Int ->
+        attempts++
+        2 * a % 2 == 0
+      }
+      attempts shouldBe 10
+    }
+
+    "forAll: one generator implicit 200 attempts" {
+      var attempts = 0
+      forAll(200) { a: Int ->
+        attempts++
+        2 * a % 2 == 0
+      }
+      attempts shouldBe 200
+    }
+
+    "forAll: two generators implicit 30 attempts" {
+      var attempts = 0
+      forAll(30) { a: String, b: String ->
+        attempts++
+        (a + b).startsWith(a)
+      }
+      attempts shouldBe 30
+    }
+
+    "forAll: Two implicit generators 500 attempts" {
+      var attempts = 0
+      forAll(500) { a: Int, b: Int ->
+        attempts++
+        a * b == b * a
+      }
+      attempts shouldBe 500
+    }
+
     "pad" {
       forAll { a: Int, b: String ->
         a <= 0 || a > 100 || b.padStart(a, ' ').length >= a
@@ -42,6 +218,417 @@ class PropertyTestingTest : StringSpec() {
       forAll { a: Double, b: Double ->
         a < b || a >= b
       }
+    }
+
+    "forAll: Three explicit generators 1000 attempts" {
+      var attempts = 0
+      forAll(Gen.int(), Gen.int(), Gen.int()) { a, b, c ->
+        attempts++
+        (a + b) + c == a + (b + c)
+      }
+      attempts shouldBe 1000
+    }
+
+    "forAll: Three explicit generators 30 attempts" {
+      var attempts = 0
+      forAll(30, Gen.int(), Gen.int(), Gen.int()) { a, b, c ->
+        attempts++
+        (a * b) * c == a * (b * c)
+      }
+      attempts shouldBe 30
+    }
+
+    "forAll: Three explicit generators 0 attempts" {
+      val exception = shouldThrow<IllegalArgumentException> {
+        forAll(0, Gen.int(), Gen.int(), Gen.int()) { a, b, c ->
+          true
+        }
+      }
+      exception.message shouldBe "Attempts should be a positive number"
+    }
+
+    "forAll: Three explicit generators -3 attempts" {
+      val exception = shouldThrow<IllegalArgumentException> {
+        forAll(-3, Gen.string(), Gen.int(), Gen.double()) { a, b, c ->
+          true
+        }
+      }
+      exception.message shouldBe "Attempts should be a positive number"
+    }
+
+    "forAll: Three explicit generators failure at the third attempt" {
+      var attempts = 0
+      var elementA = 0
+      var elementB = 0
+      var elementC = 0
+      val exception = shouldThrow<AssertionError> {
+        forAll(50, Gen.int(), Gen.int(), Gen.int()) { a, b, c ->
+          elementA = a
+          elementB = b
+          elementC = c
+          attempts++
+          attempts < 3
+        }
+      }
+
+      exception.message shouldBe "Property failed for\n$elementA\n$elementB\n$elementC\nafter 3 attempts"
+    }
+
+    "forAll : Three explicit generators failure at the 26th attempt" {
+      var attempts = 0
+      var elementA = 0
+      var elementB = 0
+      var elementC = 0
+      val exception = shouldThrow<AssertionError> {
+        forAll(50, Gen.int(), Gen.int(), Gen.int()) { a, b, c ->
+          elementA = a
+          elementB = b
+          elementC = c
+          attempts++
+          attempts < 26
+        }
+      }
+
+      exception.message shouldBe "Property failed for\n$elementA\n$elementB\n$elementC\nafter 26 attempts"
+    }
+
+    "forAll : Three implicit generators 1000 attempts" {
+      var attempts = 0
+      forAll { a: Int, b: Int, c: Int ->
+        attempts++
+        a + b + c == (a + b) + c
+      }
+      attempts shouldBe 1000
+    }
+
+    "forAll: Three implicit generators 26 attempts" {
+      var attempts = 0
+      forAll(26) { a: Int, b: Int, c: Int ->
+        attempts++
+        a + b * c == (b * c) + a
+      }
+      attempts shouldBe 26
+    }
+
+    "forAll: Four explicit generators success after 1000 attempts" {
+      var attempts = 0
+      forAll(Gen.int(), Gen.int(), Gen.int(), Gen.int()) { a, b, c, d ->
+        attempts++
+        a + b + c + d == d + c + b + a
+      }
+      attempts shouldBe 1000
+    }
+
+    "forAll: Four explicit generators success after 50 attempts" {
+      var attempts = 0
+      forAll(50, Gen.int(), Gen.int(), Gen.int(), Gen.int()) { a, b, c, d ->
+        attempts++
+        a + b + c + d == d + c + b + a
+      }
+      attempts shouldBe 50
+    }
+
+    "forAll: Four explicit generators failed after 4 attempts" {
+      var attempts = 0
+      var elementA = 0
+      var elementB = 0
+      var elementC = 0
+      var elementD = 0
+      val exception = shouldThrow<AssertionError> {
+        forAll(Gen.int(), Gen.int(), Gen.int(), Gen.int()) { a, b, c, d ->
+          attempts++
+          elementA = a
+          elementB = b
+          elementC = c
+          elementD = d
+          attempts < 4
+        }
+      }
+      exception.message shouldBe "Property failed for \n$elementA\n$elementB\n$elementC\n$elementD\nafter $attempts attempts"
+    }
+
+    "forAll: Four explicit generators failed after 50 attempts" {
+      var attempts = 0
+      var elementA = 0
+      var elementB = 0
+      var elementC = 0
+      var elementD = 0
+      val exception = shouldThrow<AssertionError> {
+        forAll(100, Gen.int(), Gen.int(), Gen.int(), Gen.int()) { a, b, c, d ->
+          elementA = a
+          elementB = b
+          elementC = c
+          elementD = d
+          attempts++
+          attempts < 50
+        }
+      }
+      exception.message shouldBe "Property failed for \n$elementA\n$elementB\n$elementC\n$elementD\nafter $attempts attempts"
+    }
+
+    "forAll: Four explicit generators with -100 attempts" {
+      val exception = shouldThrow<IllegalArgumentException> {
+        forAll(-100, Gen.int(), Gen.int(), Gen.int(), Gen.int()) { a, b, c, d ->
+          true
+        }
+      }
+
+      exception.message shouldBe "Attempts should be a positive number"
+    }
+
+    "forAll: four explicit generators with 0 attempts" {
+      val exception = shouldThrow<IllegalArgumentException> {
+        forAll(0, Gen.int(), Gen.int(), Gen.int(), Gen.int()) { a, b, c, d ->
+          true
+        }
+      }
+    }
+
+    "forAll: four implicit generators with 1000 attempts" {
+      var attempts = 0
+      forAll { a: Int, b: Int, c: Int, d: Int ->
+        attempts++
+        true
+      }
+      attempts shouldBe 1000
+    }
+
+    "forAll: four implicit generators with 20 attempts" {
+      var attempts = 0
+      forAll(20) { a: Int, b: Int, c: Int, d: Int ->
+        attempts++
+        true
+      }
+      attempts shouldBe 20
+    }
+
+    "forAll: four implicit generators with 250 attempts" {
+      var attempts = 0
+      forAll(250) { a: Int, b: Int, c: Int, d: Int ->
+        attempts++
+        true
+      }
+      attempts shouldBe 250
+    }
+
+    "forAll: five explicit generators with 1000 attempts" {
+      var attempts = 0
+      forAll(Gen.int(), Gen.int(), Gen.int(), Gen.int(), Gen.int()) { a, b, c, d, e ->
+        attempts++
+        true
+      }
+      attempts shouldBe 1000
+    }
+
+    "forAll: five explicit generators with 200 attempts" {
+      var attempts = 0
+      forAll(200, Gen.int(), Gen.int(), Gen.int(), Gen.int(), Gen.int()) { a, b, c, d, e ->
+        attempts++
+        true
+      }
+      attempts shouldBe 200
+    }
+
+    "forAll: five explicit generators failed after 10 attempts" {
+      var attempts = 0
+      var elementA = 0
+      var elementB = 0
+      var elementC = 0
+      var elementD = 0
+      var elementE = 0
+
+      val exception = shouldThrow<AssertionError> {
+        forAll(500, Gen.int(), Gen.int(), Gen.int(), Gen.int(), Gen.int()) { a, b, c, d, e ->
+          elementA = a
+          elementB = b
+          elementC = c
+          elementD = d
+          elementE = e
+          attempts++
+          attempts < 10
+        }
+      }
+
+      exception.message shouldBe "Property failed for \n$elementA\n$elementB\n$elementC\n$elementD\n$elementE\nafter $attempts attempts"
+    }
+
+    "forAll: five explicit generators failed after 50 attempts" {
+      var attempts = 0
+      var elementA = 0
+      var elementB = 0
+      var elementC = 0
+      var elementD = 0
+      var elementE = 0
+
+      val exception = shouldThrow<AssertionError> {
+        forAll(500, Gen.int(), Gen.int(), Gen.int(), Gen.int(), Gen.int()) { a, b, c, d, e ->
+          elementA = a
+          elementB = b
+          elementC = c
+          elementD = d
+          elementE = e
+          attempts++
+          attempts < 50
+        }
+      }
+
+      exception.message shouldBe "Property failed for \n$elementA\n$elementB\n$elementC\n$elementD\n$elementE\nafter $attempts attempts"
+    }
+
+    "forAll: five explicit generators with 0 attempts" {
+      val exception = shouldThrow<IllegalArgumentException> {
+        forAll(0, Gen.int(), Gen.int(), Gen.int(), Gen.int(), Gen.int()) { a, b, c, d, e ->
+          true
+        }
+      }
+      exception.message shouldBe "Attempts should be a positive number"
+    }
+
+    "forAll: five explicit generators with -20 attempts" {
+      val exception = shouldThrow<IllegalArgumentException> {
+        forAll(-20, Gen.int(), Gen.int(), Gen.int(), Gen.int(), Gen.int()) { a, b, c, d, e ->
+          true
+        }
+      }
+      exception.message shouldBe "Attempts should be a positive number"
+    }
+
+    "forAll five implicit generators with 1000 attempts" {
+      var attempts = 0
+      forAll { a: Int, b: Int, c: Int, d: Int, e: Int ->
+        attempts++
+        true
+      }
+      attempts shouldBe 1000
+    }
+
+    "forAll five implicit generators with 20 attempts" {
+      var attempts = 0
+      forAll(20) { a: Int, b: Int, c: Int, d: Int, e: Int ->
+        attempts++
+        true
+      }
+      attempts shouldBe 20
+    }
+
+    "forAll five implicit generators with 500 attempts" {
+      var attempts = 0
+      forAll(500) { a: Int, b: Int, c: Int, d: Int, e: Int ->
+        attempts++
+        true
+      }
+      attempts shouldBe 500
+    }
+
+    "forAll six explicit arguments with 1000 attempts" {
+      var attempts = 0
+      forAll(Gen.int(), Gen.int(), Gen.int(), Gen.int(), Gen.int(), Gen.int()) { a, b, c, d, e, f ->
+        attempts++
+        true
+      }
+      attempts shouldBe 1000
+    }
+
+    "forAll six explicit arguments with 50 attempts" {
+      var attempts = 0
+      forAll(50, Gen.int(), Gen.int(), Gen.int(), Gen.int(), Gen.int(), Gen.int()) { a, b, c, d, e, f ->
+        attempts++
+        true
+      }
+      attempts shouldBe 50
+    }
+
+    "forAll six explicit arguments failing at 40 attempts" {
+      var attempts = 0
+      var elementA = 0
+      var elementB = 0
+      var elementC = 0
+      var elementD = 0
+      var elementE = 0
+      var elementF = 0
+      val exception = shouldThrow<AssertionError> {
+        forAll(500, Gen.int(), Gen.int(), Gen.int(), Gen.int(), Gen.int(), Gen.int()) { a, b, c, d, e, f ->
+          elementA = a
+          elementB = b
+          elementC = c
+          elementD = d
+          elementE = e
+          elementF = f
+          attempts++
+          attempts < 40
+        }
+      }
+      exception.message shouldBe
+          "Property failed for \n$elementA\n$elementB\n$elementC\n$elementD\n$elementE\n$elementF\nafter $attempts attempts"
+    }
+
+    "forAll six explicit arguments failing at 500 attempts" {
+      var attempts = 0
+      var elementA = 0
+      var elementB = 0
+      var elementC = 0
+      var elementD = 0
+      var elementE = 0
+      var elementF = 0
+      val exception = shouldThrow<AssertionError> {
+        forAll(700, Gen.int(), Gen.int(), Gen.int(), Gen.int(), Gen.int(), Gen.int()) { a, b, c, d, e, f ->
+          elementA = a
+          elementB = b
+          elementC = c
+          elementD = d
+          elementE = e
+          elementF = f
+          attempts++
+          attempts < 500
+        }
+      }
+      exception.message shouldBe
+          "Property failed for \n$elementA\n$elementB\n$elementC\n$elementD\n$elementE\n$elementF\nafter $attempts attempts"
+    }
+
+    "forAll six explicit arguments with 0 attempts" {
+      val exception = shouldThrow<IllegalArgumentException> {
+        forAll(0, Gen.int(), Gen.int(), Gen.int(), Gen.int(), Gen.int(), Gen.int()) { a, b, c, d, e, f ->
+          true
+        }
+      }
+      exception.message shouldBe "Attempts should be a positive number"
+    }
+
+    "forAll six explicit arguments with -300 attempts" {
+      val exception = shouldThrow<IllegalArgumentException> {
+        forAll(-300, Gen.int(), Gen.int(), Gen.int(), Gen.int(), Gen.int(), Gen.int()) { a, b, c, d, e, f ->
+          true
+        }
+      }
+      exception.message shouldBe "Attempts should be a positive number"
+    }
+
+    "forAll: six implicit arguments 1000 attempts" {
+      var attempts = 0
+      forAll { a: Int, b: Double, c: String, d: Long, e: Float, f: Int ->
+        attempts++
+        true
+      }
+      attempts shouldBe 1000
+    }
+
+    "forAll: six implicit arguments 500 attempts" {
+      var attempts = 0
+      forAll(500) { a: Int, b: Double, c: String, d: Long, e: Float, f: Int ->
+        attempts++
+        true
+      }
+      attempts shouldBe 500
+    }
+
+    "forAll: six implicit arguments 20 attempts" {
+      var attempts = 0
+      forAll(20) { a: Int, b: Double, c: String, d: Long, e: Float, f: Int ->
+        attempts++
+        true
+      }
+      attempts shouldBe 20
     }
 
     "forNoneTestStrings" {

--- a/src/test/kotlin/io/kotlintest/properties/PropertyTestingTest.kt
+++ b/src/test/kotlin/io/kotlintest/properties/PropertyTestingTest.kt
@@ -1063,6 +1063,116 @@ class PropertyTestingTest : StringSpec() {
       }
       attempts shouldBe 620
     }
-  }
 
+    "forNone: five explicit generators 1000 attempts" {
+      var attempts = 0
+      forNone(Gen.string(), Gen.int(), Gen.long(), Gen.double(), Gen.string()) {
+        a, b, c, d, e -> attempts++
+        false
+      }
+      attempts shouldBe 1000
+    }
+
+    "forNone: five explicit generators 26 attempts" {
+      var attempts = 0
+      forNone(26, Gen.int(), Gen.string(), Gen.double(), Gen.long(), Gen.int()) {
+        a, b, c, d, e -> attempts++
+        false
+      }
+      attempts shouldBe 26
+    }
+
+    "forNone: five explicit generators fails after 2 attempts" {
+      var attempts = 0
+      var elementA = 0
+      var elementB = 0
+      var elementC = 0
+      var elementD = 0
+      var elementE = 0
+      val exception = shouldThrow<AssertionError> {
+        forNone(10, Gen.int(), Gen.int(), Gen.int(), Gen.int(), Gen.int()) {
+          a, b, c, d, e -> attempts++
+          elementA = a
+          elementB = b
+          elementC = c
+          elementD = d
+          elementE = e
+          attempts >= 2
+        }
+      }
+
+      exception.message shouldBe
+          "Property passed for \n$elementA\n$elementB\n$elementC\n$elementD\n$elementE\nafter $attempts attempts"
+    }
+
+    "forNone: five explicit generators fails after 2300 attempts" {
+      var attempts = 0
+      var elementA = 0
+      var elementB = 0
+      var elementC = 0
+      var elementD = 0
+      var elementE = 0
+      val exception = shouldThrow<AssertionError> {
+        forNone(3000, Gen.int(), Gen.int(), Gen.int(), Gen.int(), Gen.int()) { a, b, c, d, e ->
+          attempts++
+          elementA = a
+          elementB = b
+          elementC = c
+          elementD = d
+          elementE = e
+          attempts >= 2300
+        }
+      }
+
+      exception.message shouldBe
+          "Property passed for \n$elementA\n$elementB\n$elementC\n$elementD\n$elementE\nafter $attempts attempts"
+    }
+
+    "forNone: five explicit generators 0 attempts" {
+      val exception = shouldThrow<IllegalArgumentException> {
+        forNone(0, Gen.int(), Gen.int(), Gen.int(), Gen.int(), Gen.int()) {
+          a, b, c, d, e -> false
+        }
+      }
+
+      exception.message shouldBe "Attempts should be a positive number"
+    }
+
+    "forNone: five explicit generators -300 attempts" {
+      val exception = shouldThrow<IllegalArgumentException> {
+        forNone(-300, Gen.int(), Gen.int(), Gen.int(), Gen.int(), Gen.int()) {
+          a, b, c, d, e -> false
+        }
+      }
+
+      exception.message shouldBe "Attempts should be a positive number"
+    }
+
+    "forNone: five implicit generators 1000 attempts" {
+      var attempts = 0
+      forNone {
+        a : Int, b : Int, c : Int, d : Int, e : Int -> attempts++
+        false
+      }
+      attempts shouldBe 1000
+    }
+
+    "forNone: five implicit generators 427 attempts" {
+      var attempts = 0
+      forNone(427) {
+        a : Int, b : Int, c : Int, d : Int, e : Int -> attempts++
+        false
+      }
+      attempts shouldBe 427
+    }
+
+    "forNone: five implicit generators 2380 attempts" {
+      var attempts = 0
+      forNone(2380) {
+        a : Int, b : Int, c : Int, d : Int, e : Int -> attempts++
+        false
+      }
+      attempts shouldBe 2380
+    }
+  }
 }

--- a/src/test/kotlin/io/kotlintest/properties/PropertyTestingTest.kt
+++ b/src/test/kotlin/io/kotlintest/properties/PropertyTestingTest.kt
@@ -856,7 +856,7 @@ class PropertyTestingTest : StringSpec() {
       var attempts = 0
       forNone(300) {
         a : String, b : String -> attempts++
-        a == b
+        a == b && a != b
       }
       attempts shouldBe 300
     }
@@ -962,5 +962,107 @@ class PropertyTestingTest : StringSpec() {
 
       attempts shouldBe 1200
     }
+
+    "forNone: four explicit generators 1000 attempts" {
+      var attempts = 0
+      forNone(Gen.int(), Gen.string(), Gen.long(), Gen.double()) {
+        a, b, c, d -> attempts++
+        false
+      }
+      attempts shouldBe 1000
+    }
+
+    "forNone: four explicit generators 300 attempts" {
+      var attempts = 0
+      forNone(300, Gen.int(), Gen.string(), Gen.double(), Gen.long()) {
+        a, b, c, d -> attempts++
+        false
+      }
+      attempts shouldBe 300
+    }
+
+    "forNone: four explicit generators failure at attempt 12" {
+      var attempts = 0
+      var elementA = 0
+      var elementB = 0.0
+      var elementC = 0L
+      var elementD = emptyList<String>()
+      val exception = shouldThrow<AssertionError> {
+        forNone(600, Gen.int(), Gen.double(), Gen.long(), Gen.list(Gen.string())) { a, b, c, d ->
+          elementA = a
+          elementB = b
+          elementC = c
+          elementD = d
+          attempts++
+          attempts >= 12
+        }
+      }
+      exception.message shouldBe "Property passed for \n$elementA\n$elementB\n$elementC\n$elementD\nafter $attempts attempts"
+    }
+
+    "forNone: four explicit generators failure at attempt 3245" {
+      var attempts = 0
+      var elementA = 0
+      var elementB = ""
+      var elementC = 0L
+      var elementD = 0.0
+      val exception = shouldThrow<AssertionError> {
+        forNone(4000, Gen.int(), Gen.string(), Gen.long(), Gen.double()) {
+          a, b, c, d -> attempts++
+          elementA = a
+          elementB = b
+          elementC = c
+          elementD = d
+          attempts >= 3245
+        }
+      }
+      exception.message shouldBe "Property passed for \n$elementA\n$elementB\n$elementC\n$elementD\nafter $attempts attempts"
+    }
+
+    "forNone: four explicit generators 0 attempts" {
+      val exception = shouldThrow<IllegalArgumentException> {
+        forNone(0, Gen.int(), Gen.list(Gen.string()), Gen.double(), Gen.long()) {
+          a, b, c, d -> false
+        }
+      }
+      exception.message shouldBe "Attempts should be a positive number"
+    }
+
+    "forNone: four explicit generators -100 attempts" {
+      val exception = shouldThrow<IllegalArgumentException> {
+        forNone(-100, Gen.int(), Gen.list(Gen.string()), Gen.double(), Gen.long()) {
+          a, b, c, d -> false
+        }
+      }
+      exception.message shouldBe "Attempts should be a positive number"
+    }
+
+    "forNone: four implicit generators 1000 attempts" {
+      var attempts = 0
+      forNone {
+        a : Int, b : String, c : String, d : Long -> attempts++
+        false
+      }
+      attempts shouldBe 1000
+    }
+
+    "forNone: four implicit generators 30 attempts" {
+      var attempts = 0
+      forNone(30) {
+        a : Long, b : Int, c : Double, d : String -> attempts++
+        false
+      }
+      attempts shouldBe 30
+    }
+
+    "forNone: four implicit generators 620 attempts" {
+      var attempts = 0
+      forNone(620) {
+        a : String, b : Int, c : Double, d : Long -> attempts++
+        false
+      }
+      attempts shouldBe 620
+    }
   }
+
 }

--- a/src/test/kotlin/io/kotlintest/properties/PropertyTestingTest.kt
+++ b/src/test/kotlin/io/kotlintest/properties/PropertyTestingTest.kt
@@ -1174,5 +1174,118 @@ class PropertyTestingTest : StringSpec() {
       }
       attempts shouldBe 2380
     }
+
+    "forNone: six explicit generators 1000 attempts" {
+      var attempts = 0
+      forNone(Gen.int(), Gen.int(), Gen.int(), Gen.int(), Gen.int(), Gen.int()) {
+        a, b, c, d, e, f -> attempts++
+        false
+      }
+      attempts shouldBe 1000
+    }
+
+    "forNone: six explicit generators 300 attempts" {
+      var attempts = 0
+      forNone(300, Gen.int(), Gen.int(), Gen.int(), Gen.int(), Gen.int(), Gen.int()) {
+        a, b, c, d, e, f -> attempts++
+        false
+      }
+      attempts shouldBe 300
+    }
+
+    "forNone: six explicit generators failing after 320 attempts" {
+      var attempts = 0
+      var elementA = 0
+      var elementB = 0
+      var elementC = 0
+      var elementD = 1
+      var elementE = 0
+      var elementF = 0
+      val exception = shouldThrow<AssertionError> {
+        forNone(500, Gen.int(), Gen.int(), Gen.int(), Gen.int(), Gen.int(), Gen.int()) { a, b, c, d, e, f ->
+          attempts++
+          elementA = a
+          elementB = b
+          elementC = c
+          elementD = d
+          elementE = e
+          elementF = f
+          attempts >= 320
+        }
+      }
+      exception.message shouldBe
+          "Property passed for \n$elementA\n$elementB\n$elementC\n$elementD\n$elementE\n$elementF\nafter $attempts attempts"
+    }
+
+    "forNone: six explicit generators failing after 15 attempts" {
+      var attempts = 0
+      var elementA = 0
+      var elementB = 0
+      var elementC = 0
+      var elementD = 1
+      var elementE = 0
+      var elementF = 0
+      val exception = shouldThrow<AssertionError> {
+        forNone(100, Gen.int(), Gen.int(), Gen.int(), Gen.int(), Gen.int(), Gen.int()) { a, b, c, d, e, f ->
+          attempts++
+          elementA = a
+          elementB = b
+          elementC = c
+          elementD = d
+          elementE = e
+          elementF = f
+          attempts >= 15
+        }
+      }
+      exception.message shouldBe
+          "Property passed for \n$elementA\n$elementB\n$elementC\n$elementD\n$elementE\n$elementF\nafter $attempts attempts"
+    }
+
+    "forNone: six explicit generators 0 attempts" {
+      val exception = shouldThrow<IllegalArgumentException> {
+        forNone(0, Gen.int(), Gen.int(), Gen.int(), Gen.int(), Gen.int(), Gen.int()) { a, b, c, d, e, f ->
+          false
+        }
+      }
+
+      exception.message shouldBe "Attempts should be a positive number"
+    }
+
+    "forNone: six explicit generators -320 attempts" {
+      val exception = shouldThrow<IllegalArgumentException> {
+        forNone(-320, Gen.int(), Gen.int(), Gen.int(), Gen.int(), Gen.int(), Gen.int()) { a, b, c, d, e, f ->
+          false
+        }
+      }
+
+      exception.message shouldBe "Attempts should be a positive number"
+    }
+
+    "forNone: six implicit generators 1000 attempts" {
+      var attempts = 0
+      forNone {
+        a : Int, b : Int, c : Int, d : Int, e : Int, f : Int -> attempts++
+        false
+      }
+      attempts shouldBe 1000
+    }
+
+    "forNone: six implicit generators 26 attempts" {
+      var attempts = 0
+      forNone(26) {
+        a : Int, b : Int, c : Int, d : Int, e : Int, f : Int -> attempts++
+        false
+      }
+      attempts shouldBe 26
+    }
+
+    "forNone: six implicit generators 3678 attempts" {
+      var attempts = 0
+      forNone(3678) {
+        a : Int, b : Int, c : Int, d : Int, e : Int, f : Int -> attempts++
+        false
+      }
+      attempts shouldBe 3678
+    }
   }
 }

--- a/src/test/kotlin/io/kotlintest/properties/PropertyTestingTest.kt
+++ b/src/test/kotlin/io/kotlintest/properties/PropertyTestingTest.kt
@@ -668,5 +668,94 @@ class PropertyTestingTest : StringSpec() {
             a.keys.size + a.values.toSet().size + b.keys.size + b.values.toSet().size
       }
     }
+
+    "forNone: one explicit argument with 1000 attempts" {
+      var attempts = 0
+      forNone(Gen.string()) { a ->
+        attempts++
+        (a + "hi").endsWith("Bye")
+      }
+      attempts shouldBe 1000
+    }
+
+    "forNone: one explicit argument with 300 attempts" {
+      var attempts = 0
+      forNone(300, Gen.string()) { a ->
+        attempts++
+        (a + "hi").endsWith("Bye")
+      }
+      attempts shouldBe 300
+    }
+
+    "forNone: one explicit argument fails after 10 attempts" {
+      var attempts = 0
+      var elementA = ""
+      val exception = shouldThrow<AssertionError> {
+        forNone(400, Gen.string()) { a ->
+          elementA = a
+          attempts++
+          attempts >= 10
+        }
+      }
+      exception.message shouldBe "Property passed for\n$elementA\nafter 10 attempts"
+    }
+
+    "forNone: one explicit argument fails after 50 attempts" {
+      var attempts = 0
+      var elementA = 0
+      val exception = shouldThrow<AssertionError> {
+        forNone(100, Gen.int()) {
+          a -> elementA = a
+          attempts++
+          attempts >= 50
+        }
+      }
+      exception.message shouldBe "Property passed for\n$elementA\nafter 50 attempts"
+    }
+
+    "forNone: one explicit argument with 0 attempts" {
+      val exception = shouldThrow<IllegalArgumentException> {
+        forNone(0, Gen.int()) {
+          a -> false
+        }
+      }
+      exception.message shouldBe "Attempts should be a positive number"
+    }
+
+    "forNone: one explicit argument with -100 attempts" {
+       val exception = shouldThrow<IllegalArgumentException> {
+        forNone(-100, Gen.int()) {
+          a -> false
+        }
+      }
+      exception.message shouldBe "Attempts should be a positive number"
+    }
+
+    "forNone: one implicit argument with 1000 attempts" {
+      var attempts = 0
+      forNone {
+        a : String -> attempts++
+        false
+      }
+      attempts shouldBe 1000
+    }
+
+    "forNone: one implicit argument with 20 attempts" {
+      var attempts = 0
+      forNone(20) {
+        a : Double -> attempts++
+        false
+      }
+      attempts shouldBe 20
+    }
+
+    "forNone: one implicit argument with 100 attempts" {
+      var attempts = 0
+      forNone(100) { a: Double ->
+        attempts++
+        false
+      }
+      attempts shouldBe 100
+    }
   }
 }

--- a/src/test/kotlin/io/kotlintest/properties/PropertyTestingTest.kt
+++ b/src/test/kotlin/io/kotlintest/properties/PropertyTestingTest.kt
@@ -757,5 +757,210 @@ class PropertyTestingTest : StringSpec() {
       }
       attempts shouldBe 100
     }
+
+    "forNone: two explicit arguments with 1000 attempts" {
+      var attempts = 0
+      forNone(Gen.int(), Gen.int()) {
+        a, b -> attempts++
+        a + b != b + a
+      }
+      attempts shouldBe 1000
+    }
+
+    "forNone: two explicit arguments with 360 attempts" {
+      var attempts = 0
+      forNone(360, Gen.int(), Gen.int()) {
+        a, b -> attempts++
+        a * b != b * a
+      }
+      attempts shouldBe 360
+    }
+
+    "forNone: two explicit arguments 1492 attempts" {
+      var attempts = 0
+      forNone(1492, Gen.int(), Gen.int()) {
+        a, b -> attempts++
+        a * b == a + b
+      }
+      attempts shouldBe 1492
+    }
+
+    "forNone: two explicit arguments failing after 26 attempts" {
+      var attempts = 0
+      var string = ""
+      var double = 0.0
+      val exception = shouldThrow<AssertionError> {
+        forNone(36, Gen.string(), Gen.double()) { a, b ->
+          string = a
+          double = b
+          attempts++
+          attempts >= 26
+        }
+      }
+      exception.message shouldBe "Property passed for\n$string\n$double\nafter $attempts attempts"
+    }
+
+    "forNone: two explicit arguments failing after 56 attempts" {
+      var attempts = 0
+      var positive = 0
+      var negative = 0
+      val exception = shouldThrow<AssertionError> {
+        forNone(3650, Gen.positiveIntegers(), Gen.negativeIntegers()) {
+          p, n -> attempts++
+          positive = p
+          negative = n
+          attempts >= 56
+        }
+      }
+      exception.message shouldBe "Property passed for\n$positive\n$negative\nafter $attempts attempts"
+    }
+
+    "forNone: two explicit generators with 0 attempts" {
+      val exception = shouldThrow<IllegalArgumentException> {
+        forNone(0, Gen.int(), Gen.double()) {
+          a, b -> a.toDouble() == b && a.toDouble() != b
+        }
+      }
+      exception.message shouldBe "Attempts should be a positive number"
+    }
+
+    "forNone: two explicit generators with -367 attempts" {
+      val exception = shouldThrow<IllegalArgumentException> {
+        forNone(-367, Gen.negativeIntegers(), Gen.positiveIntegers()) {
+          a, b -> a == b
+        }
+      }
+      exception.message shouldBe "Attempts should be a positive number"
+    }
+
+    "forNone: two implicit generators 1000 attempts" {
+      var attempts = 0
+      forNone {
+        a : Int, b : String ->
+        attempts++
+        a.toString() == b
+      }
+      attempts shouldBe 1000
+    }
+
+    "forNone: two implicit generators 1066 attempts" {
+      var attempts = 0
+      forNone(1066) {
+        a : Int, b : Int -> attempts++
+        a == b && b != a
+      }
+      attempts shouldBe 1066
+    }
+
+    "forNone: two implicit generators 300 attempts" {
+      var attempts = 0
+      forNone(300) {
+        a : String, b : String -> attempts++
+        a == b
+      }
+      attempts shouldBe 300
+    }
+
+    "forNone: three explicit generators 1000 attempts" {
+      var attempts = 0
+      forNone(Gen.int(), Gen.int(), Gen.int()) {
+        a, b, c -> attempts++
+        false
+      }
+      attempts shouldBe 1000
+    }
+
+    "forNone: three explicit generators 860 attempts" {
+      var attempts = 0
+      forNone(860, Gen.int(), Gen.int(), Gen.int()) {
+        a, b, c -> attempts++
+        false
+      }
+
+      attempts shouldBe 860
+    }
+
+    "forNone: three explicit generators fails after 20 attempts" {
+      var attempts = 0
+      var elementA = 0
+      var elementB = 0
+      var elementC = 0
+      val exception = shouldThrow<AssertionError> {
+        forNone(300, Gen.int(), Gen.int(), Gen.int()) {
+          a, b, c -> attempts++
+          elementA = a
+          elementB = b
+          elementC = c
+          attempts >= 20
+        }
+      }
+      exception.message shouldBe "Property passed for\n$elementA\n$elementB\n$elementC\nafter 20 attempts"
+    }
+
+    "forNone: three explicit generators fails after 350 attempts" {
+      var attempts = 0
+      var elementA = 0
+      var elementB = 0
+      var elementC = 0
+      val exception = shouldThrow<AssertionError> {
+        forNone(700, Gen.int(), Gen.int(), Gen.int()) {
+          a, b, c -> attempts++
+          elementA = a
+          elementB = b
+          elementC = c
+          attempts >= 350
+        }
+      }
+
+      exception.message shouldBe "Property passed for\n$elementA\n$elementB\n$elementC\nafter 350 attempts"
+    }
+
+    "forNone: three explicit generators 0 attempts" {
+      val exception = shouldThrow<IllegalArgumentException> {
+        forNone(0, Gen.int(), Gen.int(), Gen.int()) {
+          a, b, c -> false
+        }
+      }
+
+      exception.message shouldBe "Attempts should be a positive number"
+    }
+
+    "forNone: three explicit generators -100 attempts" {
+      val exception = shouldThrow<IllegalArgumentException> {
+        forNone(-100, Gen.int(), Gen.int(), Gen.int()) {
+          a, b, c -> false
+        }
+      }
+
+      exception.message shouldBe "Attempts should be a positive number"
+    }
+
+    "forNone: three implicit generators 1000 attempts" {
+      var attempts = 0
+      forNone {
+        a : Int, b : Int, c : Int -> attempts++
+        false
+      }
+      attempts shouldBe 1000
+    }
+
+    "forNone: three implicit generators 700 attempts" {
+      var attempts = 0
+      forNone(700) {
+        a : Int, b : Int, c : Int -> attempts++
+        false
+      }
+      attempts shouldBe 700
+    }
+
+    "forNone: three implicit generators 1200 attempts" {
+      var attempts = 0
+      forNone(1200) {
+        a : Int, b : Int, c : Int -> attempts++
+        false
+      }
+
+      attempts shouldBe 1200
+    }
   }
 }


### PR DESCRIPTION
I was thinking that it should be possible to specify the number of attempts a piece of property-based testing is run and I was about to open an issue for it when I found issue #41 which I think is relevant. 
This PR adds an attempts parameter that can be introduce as the first parameter. When that is done, the test will only be run the number of times specified in the parameter. I have also updated the documentation to point this fact out. 