### PR TITLE
FIX: For one instance per test, interceptTestCase is called on that given instance #174

### DIFF
--- a/src/main/kotlin/io/kotlintest/Spec.kt
+++ b/src/main/kotlin/io/kotlintest/Spec.kt
@@ -113,7 +113,7 @@ abstract class Spec {
           else Executors.newFixedThreadPool(testCase.config.threads)
       notifier.fireTestStarted(testCase.description)
       val initialInterceptor = { context: TestCaseContext, testCase: () -> Unit ->
-        interceptTestCase(context, { testCase() })
+        spec.interceptTestCase(context, { testCase() })
       }
       val interceptorChain = createInterceptorChain(testCase.config.interceptors, initialInterceptor)
       val testCaseContext = TestCaseContext(spec, testCase)

--- a/src/test/kotlin/io/kotlintest/InterceptTestCaseTest.kt
+++ b/src/test/kotlin/io/kotlintest/InterceptTestCaseTest.kt
@@ -1,0 +1,22 @@
+package io.kotlintest
+
+import io.kotlintest.matchers.shouldBe
+import io.kotlintest.specs.StringSpec
+
+class InterceptTestCaseTest : StringSpec() {
+
+  override val oneInstancePerTest = true
+
+  var count = 0
+
+  override fun interceptTestCase(context: TestCaseContext, test: () -> Unit) {
+    count = 100
+    test()
+  }
+
+  init {
+    "field should have value assigned in interceptTestCase" {
+      count shouldBe 100
+    }
+  }
+}


### PR DESCRIPTION
I believe this didn't work as intended as `interceptTestCase` was called on one 'main' instance of `Spec`. 
Now it is called on the same instance of `Spec` that will be used for test. Therefore, test and `interceptTestCase` can reference class fields and it works as users coming from JUnit would expect - changing field value in `interceptTestCase` changes field value in test.