### PR TITLE
Added any() to return non-null objects

### DIFF
--- a/src/main/kotlin/io/kotlintest/mock/MockitoSugar.kt
+++ b/src/main/kotlin/io/kotlintest/mock/MockitoSugar.kt
@@ -8,3 +8,8 @@ inline fun <reified T> mock() = Mockito.mock(T::class.java)
 inline fun <reified T : Any> spy() = Mockito.spy(T::class.java)
 
 fun <A> `when`(methodCall: A): OngoingStubbing<A> = Mockito.`when`(methodCall)
+
+fun <T> any(): T {
+    Mockito.any<T>()
+    return null as T
+}


### PR DESCRIPTION
When we use mockito with kotlintest:

```
val myMock = mock()
Mockito.verify(myMock, never()).myAction(Mockito.any())
```

We have this issue:

`
java.lang.IllegalStateException: anyObject() must not be null
`

This is because `Mockito.any()` always return null, with this simple commit just call to kotlintest `any()` for solve this issue 👍 