### PR TITLE
Fix code bock formatting in the reference

### DIFF
--- a/doc/reference.md
+++ b/doc/reference.md
@@ -620,7 +620,8 @@ class MyTests : WordSpec() {
       }.config(timeout = 2.seconds)
     }
   }
-}```
+}
+```
 
 ```kotlin
 import io.kotlintest.specs.FunSpec


### PR DESCRIPTION
Before | After
--- | ---
<img width="471" alt="screen shot 2017-11-14 at 4 22 38 pm" src="https://user-images.githubusercontent.com/1626673/32788027-651023e8-c958-11e7-8f5e-59df38abdc7b.png"> | <img width="451" alt="screen shot 2017-11-14 at 4 24 36 pm" src="https://user-images.githubusercontent.com/1626673/32788035-6993689e-c958-11e7-8e46-9c8e819caea2.png">

