### PR TITLE
Clarify how includeTags/excludeTags interact with untagged tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.1.51'
+    ext.kotlin_version = '1.1.60'
     repositories {
         mavenCentral()
     }

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -709,8 +709,12 @@ class MyTest : StringSpec() {
 ```
 
 Then by invoking the test runner with a system property of `includeTags` and/or `excludeTags`, you
-can control which tests are run. If you provide more than one tag for `includeTags` or
-`excludeTags`, a test case with at least one of the given tags is included/excluded.
+can control which tests are run:
+
+* If no `includeTags` and/or `excludeTags` are specified, all tests (both tagged and untagged ones) are run.
+* If only `includeTags` are specified, only tests with that tag are run (untagged test are *not* run).
+* If only `excludeTags` are specified, only tests without that tag are run (untagged tests *are* run).
+* If you provide more than one tag for `includeTags` or `excludeTags`, a test case with at least one of the given tags is included/excluded.
 
 Provide the simple names of tag object (without package) when you run the tests. Please pay attention to the use of upper case and lower case! If two tag objects have the same simple name (in different name spaces) they are treated as the same tag.
 

--- a/src/test/kotlin/io/kotlintest/TestCaseTest.kt
+++ b/src/test/kotlin/io/kotlintest/TestCaseTest.kt
@@ -29,7 +29,7 @@ class TestCaseTest : StringSpec() {
       testTaggedA.isActive shouldBe true
       untaggedTest.isActive shouldBe false
       testTaggedB.isActive shouldBe false
-    }.config(tags = setOf(TagA))
+    }
   }
 
   override fun interceptTestCase(context: TestCaseContext, test: () -> Unit) {

--- a/src/test/kotlin/io/kotlintest/TestCaseTest.kt
+++ b/src/test/kotlin/io/kotlintest/TestCaseTest.kt
@@ -30,6 +30,12 @@ class TestCaseTest : StringSpec() {
       untaggedTest.isActive shouldBe false
       testTaggedB.isActive shouldBe false
     }
+
+    "tagged tests should be active by default" {
+      testTaggedA.isActive shouldBe true
+      untaggedTest.isActive shouldBe true
+      testTaggedB.isActive shouldBe true
+    }
   }
 
   override fun interceptTestCase(context: TestCaseContext, test: () -> Unit) {


### PR DESCRIPTION
In particular, `includeTags` does not include that tag to the set of untagged tests, but it limits the run to exactly the tag.
