### PR TITLE
Added double matching to Matchers.md (documentation only)

### DIFF
--- a/doc/matchers.md
+++ b/doc/matchers.md
@@ -44,6 +44,10 @@ This page lists all current matchers in Kotlintest.
 | -------- |
 | `double shouldBe exactly(value)`<br/>Asserts that the double is exactly equal to the given value. Exactly equal means the same representation. |
 | `double shouldBe (value plusOrMinus(tolerance))`<br/>Asserts that the double is equal to the given value within a tolerance range. This is the recommended way of testing for double equality. |
+| `double shouldBe lt(n)`<br/>Asserts that the double is less than the given value n |
+| `double shouldBe lte(n)`<br/>Asserts that the double is less or equal to than the given value n |
+| `double shouldBe gt(n)`<br/>Asserts that the double is greater than the given value n |
+| `double shouldBe gte(n)`<br/>Asserts that the double is greater than or equal to the given value n |
 
 | Collections |
 | -------- |


### PR DESCRIPTION
Not having these in the documentation might make the user believe they don't exist. As any comparable may use these assertions, it's fair to add them to the double type