### PR TITLE
Allow Eventually to use a predicate for additional flexibility

### DIFF
--- a/src/main/kotlin/io/kotlintest/Eventually.kt
+++ b/src/main/kotlin/io/kotlintest/Eventually.kt
@@ -21,3 +21,17 @@ fun <T, E : Throwable>eventually(duration: Duration, exceptionClass: Class<E>, f
   }
   throw AssertionError("Test failed after ${duration.amount} ${duration.timeUnit}; attempted $times times")
 }
+
+fun <T>eventually(duration: Duration, predicate: (T) -> Boolean, f: () -> T): T {
+  val end = System.nanoTime() + duration.nanoseconds
+  var times = 0
+  while (System.nanoTime() < end) {
+    val result = f()
+    if (predicate(result)) {
+      return result
+    } else {
+      times++
+    }
+  }
+  throw AssertionError("Test failed after ${duration.amount} ${duration.timeUnit}; attempted $times times")
+}

--- a/src/test/kotlin/io/kotlintest/EventuallyTest.kt
+++ b/src/test/kotlin/io/kotlintest/EventuallyTest.kt
@@ -56,6 +56,19 @@ class EventuallyTest : WordSpec() {
             throw FileNotFoundException("foo")
         }
       }
+      "fail tests that fail a predicate" {
+        shouldThrow<AssertionError> {
+          eventually(2.seconds, { it == 2 }) {
+            1
+          }
+        }
+      }
+      "pass tests that pass a predicate" {
+        val result = eventually(2.seconds, { it == 1 }) {
+            1
+        }
+        result shouldBe 1
+      }
     }
   }
 }


### PR DESCRIPTION
If you're testing code that fails but doesn't throw exceptions, for example checking an HTTP status code, you might want to just pass an arbitrary predicate instead of relying on an Exception to signal a failure.

As an aside, I have no idea how to run tests in this project, 
```
./gradlew test
```

compiles tests but per the generated report at 
kotlintest/build/reports/tests/test/index.html

Nothing is actually running.  I also tried to write some failing tests, but again, nothing fails from the gradle test task. 

Am I running this the wrong way?  I checked travis, but travis seems to use the test task as well.