### PR TITLE
Update: minor optimization for `Gen::nats` and `Gen::negativeIntegers…

### DIFF
--- a/src/main/kotlin/io/kotlintest/properties/Gen.kt
+++ b/src/main/kotlin/io/kotlintest/properties/Gen.kt
@@ -6,6 +6,7 @@ import java.lang.reflect.ParameterizedType
 import java.lang.reflect.Type
 import java.lang.reflect.WildcardType
 import java.util.Random
+import kotlin.math.abs
 
 /** A shared random number generator. */
 private val RANDOM = Random()
@@ -53,7 +54,8 @@ interface Gen<out T> {
     fun nats() = object : Gen<Int> {
       override fun generate(): Int {
         while (true) {
-          val next = RANDOM.nextInt()
+          val next = abs(RANDOM.nextInt())
+          // in case next is Int.MIN_VALUE
           if (next >= 0)
             return next
         }
@@ -62,11 +64,7 @@ interface Gen<out T> {
 
     fun negativeIntegers() = object : Gen<Int> {
       override fun generate(): Int {
-        while (true) {
-          val next = RANDOM.nextInt()
-          if (next < 0)
-            return next
-        }
+        return -abs(RANDOM.nextInt())
       }
     }
 


### PR DESCRIPTION
Here's a minor optimization for Gen's `nats()` and `negativeIntegers()` that uses `abs` to reduce the number of out-of-range values.