### PR TITLE
Allowing supertypes in shouldThrow matcher

### DIFF
--- a/src/main/kotlin/io/kotlintest/matchers/Matcher.kt
+++ b/src/main/kotlin/io/kotlintest/matchers/Matcher.kt
@@ -1,5 +1,7 @@
 package io.kotlintest.matchers
 
+import kotlin.reflect.full.isSubclassOf
+
 interface Matcher<T> {
 
   fun test(value: T): Result
@@ -33,11 +35,9 @@ inline fun <reified T> shouldThrow(thunk: () -> Any?): T {
     e
   }
 
-  val exceptionClassName = T::class.qualifiedName
-
   if (e == null)
     throw AssertionError("Expected exception ${T::class.qualifiedName} but no exception was thrown")
-  else if (e.javaClass.canonicalName != exceptionClassName)
+  else if (!e::class.isSubclassOf(T::class))
     throw AssertionError("Expected exception ${T::class.qualifiedName} but ${e.javaClass.name} was thrown", e)
   else
     return e as T

--- a/src/test/kotlin/io/kotlintest/matchers/ExceptionMatchersTest.kt
+++ b/src/test/kotlin/io/kotlintest/matchers/ExceptionMatchersTest.kt
@@ -20,13 +20,9 @@ class ExceptionMatchersTest : FreeSpec() {
         } catch (e: AssertionError) {
         }
       }
-      "should test for throwables" {
-        try {
-          shouldThrow<Throwable> {
-            throw Throwable("bibble")
-          }
-          throw RuntimeException("If we get here its a bug")
-        } catch (e: AssertionError) {
+      "expecting thrown exception supertype is allowed" {
+        shouldThrow<RuntimeException> {
+          throw UnsupportedOperationException("bibble")
         }
       }
       "return matched exception" {


### PR DESCRIPTION
While introducing my change the following test started failing. https://github.com/kotlintest/kotlintest/blob/c2c1e925ece52e94bc95fc7ba2e176d6297142ab/src/test/kotlin/io/kotlintest/matchers/ExceptionMatchersTest.kt#L23-L31

Throwing Throwable and expecting Throwable is currently causing AssertionError. I do not understand how is that test valid to be honest. Am I missing something?

I have replaced that test case with the one that is working for Supertypes.

WDYT?