### PR TITLE
Simplify how Travis calls Gradle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ cache:
 
 install: /bin/true
 
-script: ./gradlew wrapper --gradle-version 4.6 clean test
+script: ./gradlew test


### PR DESCRIPTION
There is no need to call the wrapper task with a version here as we
already use the wrapper script, and that one will bootstrap the Gradle
version as specified in gradle/wrapper/gradle-wrapper.properties.

Also, there is no need to call the clean task as each Travis build
starts from scratch.