### PR TITLE
Enable the Gradle build cache to reduce build time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,15 @@ jdk:
 
 sudo: false
 
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+
 cache:
   directories:
-  - $HOME/.m2
-  - $HOME/.gradle
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
+    - $HOME/.m2/repository/
 
 install: /bin/true
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,3 +7,5 @@ ossrhUsername=xx
 ossrhPassword=xx
 
 version=3.1.0-SNAPSHOT
+
+org.gradle.caching=true


### PR DESCRIPTION
This is a cache that is persistent across clean builds, see

https://docs.gradle.org/current/userguide/build_cache.html

Adjust cached directories on Travis accordingly.