### PR TITLE
Add Gen.oneOf

### DIFF
--- a/kotlintest-assertions/src/main/kotlin/io/kotlintest/properties/Gen.kt
+++ b/kotlintest-assertions/src/main/kotlin/io/kotlintest/properties/Gen.kt
@@ -209,6 +209,24 @@ interface Gen<T> {
               }
     }
 
+    fun <A> oneOf(vararg gens: Gen<A>): Gen<A> = object : Gen<A> {
+      override fun constants(): Iterable<A> = gens.flatMap { it.constants() }
+
+      override fun random(): Sequence<A> {
+        assert(gens.isNotEmpty(), { "List of generators cannot be empty" })
+
+        val iterators = gens.map { it.random().iterator() }
+
+        return generateInfiniteSequence {
+          val iteratorLocation = JavaRandoms.internalNextInt(RANDOM, 0, iterators.size)
+          val iterator = iterators[iteratorLocation]
+          iterator.next()
+        }
+
+      }
+
+    }
+
     fun bigInteger(maxNumBits: Int = 32): Gen<BigInteger> = BigIntegerGen(maxNumBits)
 
     /**

--- a/kotlintest-tests/src/test/kotlin/com/sksamuel/kotlintest/tests/properties/GenBindTest.kt
+++ b/kotlintest-tests/src/test/kotlin/com/sksamuel/kotlintest/tests/properties/GenBindTest.kt
@@ -2,12 +2,13 @@
 
 package com.sksamuel.kotlintest.tests.properties
 
+import io.kotlintest.*
 import io.kotlintest.matchers.beGreaterThan
 import io.kotlintest.matchers.beLessThan
+import io.kotlintest.matchers.haveSize
+import io.kotlintest.matchers.singleElement
 import io.kotlintest.properties.Gen
 import io.kotlintest.properties.assertAll
-import io.kotlintest.should
-import io.kotlintest.shouldNotBe
 import io.kotlintest.specs.StringSpec
 import io.kotlintest.matchers.doubles.beGreaterThan as gtd
 
@@ -62,4 +63,5 @@ class GenBindTest : StringSpec({
       it.d should beLessThan(0)
     }
   }
+
 })

--- a/kotlintest-tests/src/test/kotlin/com/sksamuel/kotlintest/tests/properties/GenTest.kt
+++ b/kotlintest-tests/src/test/kotlin/com/sksamuel/kotlintest/tests/properties/GenTest.kt
@@ -2,15 +2,14 @@
 
 package com.sksamuel.kotlintest.tests.properties
 
-import io.kotlintest.forAll
+import io.kotlintest.*
+import io.kotlintest.matchers.beGreaterThan
 import io.kotlintest.matchers.collections.contain
 import io.kotlintest.matchers.gte
 import io.kotlintest.matchers.lt
 import io.kotlintest.matchers.string.include
 import io.kotlintest.properties.Gen
-import io.kotlintest.shouldBe
-import io.kotlintest.shouldHave
-import io.kotlintest.shouldThrow
+import io.kotlintest.properties.forAll
 import io.kotlintest.specs.WordSpec
 import io.kotlintest.tables.headers
 import io.kotlintest.tables.row
@@ -244,6 +243,25 @@ class GenTest : WordSpec() {
         io.kotlintest.properties.forAll(Gen.constant(null as Int?)) {n ->
           n == null
         }
+      }
+    }
+
+    "Gen.oneOf" should {
+      "correctly handle multiple generators" {
+        val gen = Gen.oneOf(Gen.positiveIntegers(), Gen.negativeIntegers())
+        var positiveNumbers = 0
+        var negativeNumbers = 0
+        forAll(gen) {
+          if (it > 0) {
+            positiveNumbers++
+          } else if (it < 0) {
+            negativeNumbers++
+          }
+          it shouldNotBe 0
+          true
+        }
+        positiveNumbers shouldBe beGreaterThan(1)
+        negativeNumbers shouldBe beGreaterThan(1)
       }
     }
 


### PR DESCRIPTION
I'm rewriting tests on Arrow to KotlinTest and we're using Gen.oneOf a lot there. So I've decided to rewrite it for new generators.