### PR TITLE
AppVeyor: Only create %HOME%\.gradle if it does not exist

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ configuration:
 # Do something useful here to override the default MSBuild (which would fail otherwise).
 build_script:
   - if %CONFIGURATION%==Java9 (
-      mkdir %HOME%\.gradle &
+      if not exist %HOME%\.gradle mkdir %HOME%\.gradle &
       echo org.gradle.java.home=C:/Program Files/Java/jdk9>%HOME%\.gradle\gradle.properties)
   - gradlew --info
 


### PR DESCRIPTION
This avoids a bogus build failure if it already exists.