### PR TITLE
AppVeyor: Create %HOME%\.gradle independently of the configuration

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,9 +21,8 @@ configuration:
 
 # Do something useful here to override the default MSBuild (which would fail otherwise).
 build_script:
-  - if %CONFIGURATION%==Java9 (
-      if not exist %HOME%\.gradle mkdir %HOME%\.gradle &
-      echo org.gradle.java.home=C:/Program Files/Java/jdk9>%HOME%\.gradle\gradle.properties)
+  - if not exist %HOME%\.gradle mkdir %HOME%\.gradle
+  - if %CONFIGURATION%==Java9 echo org.gradle.java.home=C:/Program Files/Java/jdk9>%HOME%\.gradle\gradle.properties
   - gradlew --info
 
 test_script:


### PR DESCRIPTION
This fixes gradle.properties not being written if %HOME%\.gradle already
existed.