### PR TITLE
Change jUnit 4 Runner to show nested tests.

### DIFF
--- a/kotlintest-runner/kotlintest-runner-junit4/build.gradle
+++ b/kotlintest-runner/kotlintest-runner-junit4/build.gradle
@@ -1,6 +1,10 @@
+test {
+	exclude 'io/kotlintest/runner/junit4/samples/**'
+}
 dependencies {
     compile project(':kotlintest-core')
     compile project(':kotlintest-assertions')
     compile project(':kotlintest-runner:kotlintest-runner-jvm')
     compile 'junit:junit:4.12'
+    testCompile "com.nhaarman:mockito-kotlin-kt1.1:1.5.0"
 }

--- a/kotlintest-runner/kotlintest-runner-junit4/src/main/kotlin/io/kotlintest/runner/junit4/JUnitTestRunnerListener.kt
+++ b/kotlintest-runner/kotlintest-runner-junit4/src/main/kotlin/io/kotlintest/runner/junit4/JUnitTestRunnerListener.kt
@@ -21,17 +21,22 @@ class JUnitTestRunnerListener(val testClass: KClass<out Spec>,
       }
 
   override fun executionStarted(scope: Scope) {
-    notifier.fireTestStarted(desc(scope))
+    notifier.fireTestStarted(describeScope(scope))
   }
 
   override fun executionFinished(scope: Scope, result: TestResult) {
-    val desc = desc(scope)
+    val desc = describeScope(scope)
     when (result.status) {
       TestStatus.Success -> notifier.fireTestFinished(desc)
-      TestStatus.Error -> notifier.fireTestFailure(Failure(desc, result.error))
+      TestStatus.Error -> notifyFailure(desc, result)
       TestStatus.Ignored -> notifier.fireTestIgnored(desc)
-      TestStatus.Failure -> notifier.fireTestFailure(Failure(desc, result.error))
+      TestStatus.Failure -> notifyFailure(desc, result)
     }
+  }
+
+  private fun notifyFailure(description: JDescription, result: TestResult) {
+    notifier.fireTestFailure(Failure(description, result.error))
+    notifier.fireTestFinished(description)
   }
 
   override fun executionStarted() {}

--- a/kotlintest-runner/kotlintest-runner-junit4/src/main/kotlin/io/kotlintest/runner/junit4/KotlinTestRunner.kt
+++ b/kotlintest-runner/kotlintest-runner-junit4/src/main/kotlin/io/kotlintest/runner/junit4/KotlinTestRunner.kt
@@ -1,12 +1,17 @@
 package io.kotlintest.runner.junit4
 
 import io.kotlintest.Spec
+import io.kotlintest.Scope
+import io.kotlintest.TestContainer
 import io.kotlintest.runner.jvm.TestRunner
+import io.kotlintest.runner.jvm.createSpecInstance
+import io.kotlintest.runner.jvm.AsynchronousTestContext
 import org.junit.runner.Description
 import org.junit.runner.Runner
+import org.junit.runners.ParentRunner
 import org.junit.runner.notification.RunNotifier
 
-class KotlinTestRunner(val testClass: Class<out Spec>) : Runner() {
+class KotlinTestRunner(private val testClass: Class<out Spec>) : Runner() {
 
   override fun run(notifier: RunNotifier) {
     val listener = JUnitTestRunnerListener(testClass.kotlin, notifier)
@@ -15,6 +20,19 @@ class KotlinTestRunner(val testClass: Class<out Spec>) : Runner() {
   }
 
   override fun getDescription(): Description =
-      Description.createSuiteDescription(testClass)
+      describeScope(createSpecInstance(testClass.kotlin).root())
 
+  /*override fun runChild(child: Scope, notifier: RunNotifier) {
+      notifier.fireTestStarted(describeScope(child))
+  }
+
+  override fun getChildren(): List<Scope> {
+	  val spec = createSpecInstance(testClass.kotlin)
+	  val context = AsynchronousTestContext(spec.root())
+	  spec.root().closure(context)
+	  return context.scopes()
+  }
+
+  override fun describeChild(child: Scope): Description =
+	  describeScope(child)*/
 }

--- a/kotlintest-runner/kotlintest-runner-junit4/src/main/kotlin/io/kotlintest/runner/junit4/RunnerHelpers.kt
+++ b/kotlintest-runner/kotlintest-runner-junit4/src/main/kotlin/io/kotlintest/runner/junit4/RunnerHelpers.kt
@@ -1,0 +1,29 @@
+package io.kotlintest.runner.junit4
+
+import io.kotlintest.*
+import io.kotlintest.runner.jvm.TestRunner
+import io.kotlintest.runner.jvm.createSpecInstance
+import io.kotlintest.runner.jvm.AsynchronousTestContext
+import org.junit.runner.Description
+import org.junit.runner.notification.RunNotifier
+
+internal tailrec fun describeScope(scope: Scope): Description =
+  when(scope) {
+      is TestContainer -> describeTestContainer(scope)
+      is TestCase -> describeTestCase(scope)
+      else -> Description.createSuiteDescription(scope::class.java)
+  }
+
+
+private fun describeTestContainer(container: TestContainer): Description {
+  val description = Description
+      .createTestDescription(container.sourceClass.java, container.description.fullName())
+  
+  val context = AsynchronousTestContext(container)
+  container.closure(context)
+  context.scopes().forEach { description.addChild(describeScope(it)) }
+  return description
+}
+
+private fun describeTestCase(case: TestCase): Description =
+    Description.createTestDescription(case.spec::class.java, case.description.fullName())

--- a/kotlintest-runner/kotlintest-runner-junit4/src/test/kotlin/com/sksamuel/kotlintest/runner/junit4/KotlinTestRunnerTest.kt
+++ b/kotlintest-runner/kotlintest-runner-junit4/src/test/kotlin/com/sksamuel/kotlintest/runner/junit4/KotlinTestRunnerTest.kt
@@ -1,0 +1,93 @@
+package io.kotlintest.runner.junit4
+
+import org.junit.Test
+import org.junit.runner.Runner
+import org.junit.runner.notification.*
+import io.kotlintest.*
+import io.kotlintest.should
+import io.kotlintest.shouldBe
+import io.kotlintest.matchers.*
+import io.kotlintest.matchers.types.*
+import com.sksamuel.kotlintest.runner.junit4.HelloWorldTest
+import io.kotlintest.specs.*
+import com.nhaarman.mockito_kotlin.*
+import io.kotlintest.runner.junit4.samples.*
+
+
+class KotlinTestRunnerTest {
+	@Test
+	fun `should be a runner`() {
+		KotlinTestRunner(Spec::class.java) should beInstanceOf(Runner::class)
+	}
+
+	@Test
+	fun `should return a list of scopes when calling get children`() {
+		val runner = KotlinTestRunner(HelloWorldTest::class.java)
+		val children = 
+			runner.getDescription().getChildren()
+		children should haveSize(2)
+		children[0].apply {
+			isTest() shouldBe true
+			isSuite() shouldBe false
+			testCount() shouldBe 1
+			getMethodName() shouldBe "HelloWorldTest first test ()"
+		}
+		children[1].apply {
+			isTest() shouldBe false
+			isSuite() shouldBe true
+			testCount() shouldBe 2
+			getMethodName() shouldBe "HelloWorldTest string tests .@#@$#(!)@#" 
+			val tests = getChildren()
+			tests should haveSize(2)
+			tests[0].apply {
+				isTest() shouldBe true
+				isSuite() shouldBe false
+				testCount() shouldBe 1
+				getMethodName() shouldBe "HelloWorldTest string tests .@#@$#(!)@# substring" 
+			}
+
+			tests[1].apply {
+				isTest() shouldBe true
+				isSuite() shouldBe false
+				testCount() shouldBe 1
+				getMethodName() shouldBe "HelloWorldTest string tests .@#@$#(!)@# startsWith" 
+			}
+		}
+	}
+
+	@Test
+	fun `should run children and report results`() {
+		val listener = mock<RunListener> {}
+		val notifier = RunNotifier()
+		notifier.addListener(listener)
+		val runner = KotlinTestRunner(SomeBehaviourSpec::class.java)
+		runner.run(notifier)
+		then(listener).should()
+			.testStarted(argThat { getMethodName() == "SomeBehaviourSpec Given I have a 1" })
+		then(listener).should()
+			.testStarted(argThat { getMethodName() == "SomeBehaviourSpec Given I have a 1 When I add a 2" })
+		then(listener).should()
+			.testStarted(argThat { getMethodName() == "SomeBehaviourSpec Given I have a 1 When I add a 2 Then I get a 3" })
+		then(listener).should()
+			.testFinished(argThat { getMethodName() == "SomeBehaviourSpec Given I have a 1 When I add a 2 Then I get a 3" })
+		then(listener).should()
+			.testFinished(argThat { getMethodName() == "SomeBehaviourSpec Given I have a 1 When I add a 2" })
+		then(listener).should()
+			.testFinished(argThat { getMethodName() == "SomeBehaviourSpec Given I have a 1" })
+		then(listener).should()
+			.testStarted(argThat { getMethodName() == "SomeBehaviourSpec Given Big Brother says 2 + 2 = 5" })
+		then(listener).should()
+			.testStarted(argThat { getMethodName() == "SomeBehaviourSpec Given Big Brother says 2 + 2 = 5 When I add 2 + 2" })
+		then(listener).should()
+			.testStarted(argThat { getMethodName() == "SomeBehaviourSpec Given Big Brother says 2 + 2 = 5 When I add 2 + 2 Then I should get 5" })
+		then(listener).should()
+			.testFailure(argThat { getDescription().getMethodName() ==  "SomeBehaviourSpec Given Big Brother says 2 + 2 = 5 When I add 2 + 2 Then I should get 5" })
+		then(listener).should()
+			.testFinished(argThat { getMethodName() == "SomeBehaviourSpec Given Big Brother says 2 + 2 = 5 When I add 2 + 2 Then I should get 5" })
+		then(listener).should()
+			.testFinished(argThat { getMethodName() == "SomeBehaviourSpec Given Big Brother says 2 + 2 = 5 When I add 2 + 2" })
+		then(listener).should()
+			.testFinished(argThat { getMethodName() == "SomeBehaviourSpec Given Big Brother says 2 + 2 = 5 When I add 2 + 2" })
+	}
+}
+

--- a/kotlintest-runner/kotlintest-runner-junit4/src/test/kotlin/com/sksamuel/kotlintest/runner/junit4/SampleSpecs.kt
+++ b/kotlintest-runner/kotlintest-runner-junit4/src/test/kotlin/com/sksamuel/kotlintest/runner/junit4/SampleSpecs.kt
@@ -1,0 +1,35 @@
+package io.kotlintest.runner.junit4.samples
+
+import io.kotlintest.*
+import io.kotlintest.should
+import io.kotlintest.shouldBe
+import io.kotlintest.matchers.*
+import io.kotlintest.matchers.types.*
+import io.kotlintest.specs.*
+
+/**
+* This file contains Specs that are used to test the runner itself. These
+* specs are ignored in Gradle in order to avoid false build failures.
+*/
+
+class SomeBehaviourSpec: BehaviorSpec({
+	Given("I have a 1") {
+		val one = 1
+
+		When("I add a 2") {
+			val two = 2
+
+			Then("I get a 3") {
+				one + two shouldBe 3
+			}
+		}
+	}
+
+	Given("Big Brother says 2 + 2 = 5") {
+		When("I add 2 + 2") {
+			Then("I should get 5") {
+				2 + 2 shouldBe 5
+			}
+		}
+	}
+})


### PR DESCRIPTION
This version of the jUnit 4 runner should display test nested. Some caveats:
- I have only tested success and error cases. I believe the behaviour for ignore should work too but it would be worth writing some unit tests to make sure this is the case.
- As I've seen in the jUnit reports, only the leaf is marked as failed. This differs from the 2.x version which would mark the intermediate nodes as failed too. It would be worth looking at it.

Finally, this PR contains a Spec which contains a failing Spec so that the error case can be tested through the runner. The Gradle tests for this module, i.e. the jUnit 4 runner has been configured to ignore that Spec in order to avoid false positives. 