### PR TITLE
[Feature] Inspectors: inspecting & extracting

### DIFF
--- a/kotlintest-assertions/src/main/kotlin/io/kotlintest/Inspectors.kt
+++ b/kotlintest-assertions/src/main/kotlin/io/kotlintest/Inspectors.kt
@@ -82,6 +82,70 @@ fun <T> forNone(col: Collection<T>, f: (T) -> Unit) {
   }
 }
 
+/**
+ * Inspecting allows to assert the properties of an object in a typed fashion providing a proper testing context.
+ *
+ * The **simple example** shows how inspecting can build up a assertion context making the tests more readable.
+ * ```
+ * inspecting(person){
+ *  name shouldBe "John Doe"
+ *  age shouldBe 20
+ * }
+ * ```
+ *
+ * The **elaborate example** shows that inspecting can be used in a nested fashion in combination with other inspectors
+ * to simplify the property accesses.
+ * ```
+ * inspecting(person){
+ *   name shouldBe "John Doe"
+ *   age shouldBe 20
+ *   forOne(friends){
+ *     inspecting(it){
+ *       name shouldBe "Samantha Rose"
+ *       age shouldBe 19
+ *     }
+ *   }
+ * }
+ * ```
+ * @param obj the object that is being inspected
+ * @param inspector the inspector in which further assertions and inspections can be done
+ * @author Hannes Thaller
+ */
+fun <K> inspecting(obj: K, inspector: K.() -> Unit) {
+    obj.inspector()
+}
+
+/**
+ * `extracting` pulls property values out of a list of objects for _typed_ bulk assertions on properties.
+ *
+ * The **simple example** shows how `extracting` helps with disjunct collection assertions:
+ * ```
+ * extracting(persons){ name }
+ *   .shouldContainAll("John Doe", "Samantha Roes")
+ * ```
+ *
+ * This is similar to using multiple [forOne] however allows for a more concise notation.
+ * ```
+ * forOne(persons){ it.name shouldBe "John Doe" }
+ * forOne(persons){ it.name shouldBe "Samantha Rose" }
+ * ```
+ *
+ * `extracting` also allows to define complex return types shown in this **elaborate example**:
+ * ```
+ * extracting(persons){ Pair(name, age) }
+ *   .shouldContainAll(
+ *     Pair("John Doe", 20),
+ *     Pair("Samantha Roes", 19)
+ *   )
+ * ```
+ * @param col the collection of objects from which to extract the properties
+ * @param extractor the extractor that defines _which_ properties are returned
+ * @author Hannes Thaller
+ */
+fun <K, T> extracting(col: Collection<K>, extractor: K.() -> T): List<T> {
+    return col.map(extractor)
+}
+
 private fun <T> buildAssertionError(msg: String, results: List<Pair<T, String?>>): String {
 
   val passed = results.filter { it.second == null }

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/InspectorsTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/InspectorsTest.kt
@@ -237,7 +237,77 @@ The following elements failed:
 3 => expected: 33 but was: 3
 4 => expected: 33 but was: 4
 5 => expected: 33 but was: 5"""
-      }
+            }
+        }
+
+
+        data class Person(val name: String, val age: Int, val friends: List<Person>)
+
+        val p1 = Person("John Doe", 20, emptyList())
+        val p2 = Person("Samantha Rose", 19, listOf(p1))
+        val persons = listOf(p1, p2)
+
+        "inspecting" should {
+            "expose properties"{
+                inspecting(p1) {
+                    name shouldBe "John Doe"
+                    age shouldBe 20
+                }
+            }
+
+            "be usable within other inspectors"{
+                forOne(persons) {
+                    inspecting(it) {
+                        name shouldBe "John Doe"
+                        age shouldBe 20
+                    }
+                }
+            }
+
+            "be nestable"{
+                inspecting(p2) {
+                    name shouldBe "Samantha Rose"
+                    age shouldBe 19
+                    inspecting(friends.first()) {
+                        name shouldBe "John Doe"
+                        age shouldBe 20
+                    }
+                }
+            }
+            "should fail if the matchers fail"{
+                shouldThrowAny{
+                    inspecting(p2) {
+                        name shouldBe "Samantha Rose"
+                        age shouldBe 19
+                        inspecting(friends.first()) {
+                            name shouldBe "<Some name that is wrong>"
+                            age shouldBe 19
+                        }
+                    }
+                }.message shouldBe "expected:<[<Some name that is wrong>]> but was:<[John Doe]>"
+            }
+        }
+
+        "extracting" should {
+            "extract simple properties"{
+                extracting(persons) { name }
+                        .shouldContainAll("John Doe", "Samantha Rose")
+            }
+
+            "extract complex properties"{
+                extracting(persons) { Pair(name, age) }
+                        .shouldContainAll(
+                                Pair("John Doe", 20),
+                                Pair("Samantha Rose", 19)
+                        )
+            }
+            "fail if the matcher fails"{
+                shouldThrowAny {
+                    extracting(persons) { name }
+                            .shouldContainAll("<Some name that is wrong>")
+                }.message shouldBe  "Collection should contain all of <Some name that is wrong>"
+            }
+
+        }
     }
-  }
 }


### PR DESCRIPTION
Thought I provide you with two operators I used in my project.

**Context**
I testest a graph like structure and made up a small test graph in which I wanted to check whether properties were correctly set. Testing graphs is always annoying and a lot of work.

**Problem**
I needed to check several properties, leading to a lot of code similar to this one:
```kotlin
node1.prop1 shouldBe xxx
node1.prop2 shouldBe yyy
node1.prop3 shouldBe zzz

forOne(node1.prop4){
  it.name shouldBe "name1"
}
forOne(node1.prop4){
  it.name shouldBe "name2"
}
```
**Solution/Helpers**
I defined two very simple methods that allow a simpler to read and comprehend version.
**inspecting**
*inspect* exposes the properties and provides an assertion/mental context
```kotlin
inspecting(node1){
  prop1 shouldBe xxx
  prop2 shouldBe yyy
  prop3 shouldBe zzz
}
```

**extracting**
Extracting allows to pull out properties from a collection to make *or* assertions. *forOne* only allows *and* assertions, however, i might have missed something in your documentation.
```kotlin
extracting(node1.prop4){ name }
  .shouldContainAll("name1", "name2")
```

In sum, I think these two fit well in the kotlintest dsl and are a simple but useful addition.
Furthermore, I think all inspectors should work similar to *inspecting*, i.e., providing the context relative to the inspected object; however, this is another topic.