### PR TITLE
fix eventually nanos conversion

### DIFF
--- a/kotlintest-assertions/src/main/kotlin/io/kotlintest/Eventually.kt
+++ b/kotlintest-assertions/src/main/kotlin/io/kotlintest/Eventually.kt
@@ -6,7 +6,7 @@ import java.time.Duration
 fun <T> eventually(duration: Duration, f: () -> T): T = eventually(duration, Exception::class.java, f)
 
 fun <T, E : Throwable> eventually(duration: Duration, exceptionClass: Class<E>, f: () -> T): T {
-  val end = System.nanoTime() + duration.toMillis() * 1000
+  val end = System.nanoTime() + duration.toNanos()
   var times = 0
   while (System.nanoTime() < end) {
     try {
@@ -24,7 +24,7 @@ fun <T, E : Throwable> eventually(duration: Duration, exceptionClass: Class<E>, 
 }
 
 fun <T> eventually(duration: Duration, predicate: (T) -> Boolean, f: () -> T): T {
-  val end = System.nanoTime() + duration.toMillis() * 1000
+  val end = System.nanoTime() + duration.toNanos()
   var times = 0
   while (System.nanoTime() < end) {
     val result = f()

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/EventuallyTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/EventuallyTest.kt
@@ -19,7 +19,7 @@ class EventuallyTest : WordSpec() {
       }
       "pass tests that completed within the time allowed"  {
         val end = System.currentTimeMillis() + 2000
-        eventually(Duration.ofDays(5)) {
+        eventually(Duration.ofSeconds(3)) {
           if (System.currentTimeMillis() < end)
             throw RuntimeException("foo")
         }


### PR DESCRIPTION
After upgrading from kotlintest 2->3, some of our tests failed because eventually wasn't waiting nearly long enough.  Looks like as part of the migration to use Duration, there was some bad math in converting millis to nanos.  There are `1_000_000` nanos in a millisecond, not `1_000` (I had to look this up - I would've thought it was a thousand too!).

Adjusting the test as I did below without modifying Eventually.kt shows the issue, and fails with an error like this:
`java.lang.AssertionError: Test failed after 3 seconds; attempted 942 times`

