### PR TITLE
Fixing argument names in ReplaceWith of deprecated matchers

### DIFF
--- a/kotlintest-assertions/src/main/kotlin/io/kotlintest/matchers/migration.kt
+++ b/kotlintest-assertions/src/main/kotlin/io/kotlintest/matchers/migration.kt
@@ -8,10 +8,10 @@ import io.kotlintest.shouldNotBe
 import io.kotlintest.shouldNot
 import io.kotlintest.shouldThrow
 
-@Deprecated("use the equivalent function io.kotlintest.shouldBe", ReplaceWith("shouldBe(matcher)", "io.kotlintest.shouldBe"))
+@Deprecated("use the equivalent function io.kotlintest.shouldBe", ReplaceWith("shouldBe(any)", "io.kotlintest.shouldBe"))
 infix fun <T, U : T> T.shouldBe(any: U?) = shouldBe(any)
 
-@Deprecated("use the equivalent function io.kotlintest.shouldNotBe", ReplaceWith("shouldNotBe(matcher)", "io.kotlintest.shouldNotBe"))
+@Deprecated("use the equivalent function io.kotlintest.shouldNotBe", ReplaceWith("shouldNotBe(any)", "io.kotlintest.shouldNotBe"))
 infix fun <T> T.shouldNotBe(any: Any?) = shouldNotBe(any)
 
 @Deprecated("use the equivalent function io.kotlintest.shouldNot", ReplaceWith("shouldNot(matcher)", "io.kotlintest.shouldNot"))


### PR DESCRIPTION
Currently arguments name in 'ReplaceWith' don't match so Intellij substitutes new method incorrecly. This commit fixes that and Intellij can do automatic substitution - which does pretty much nothing in this case, but it's better than doing it incorrectly. Still it can't substitute imports, but I'm afraid there is nothing we can do about it.