### PR TITLE
Fixing function return type in documentation for forAll()

### DIFF
--- a/doc/reference.md
+++ b/doc/reference.md
@@ -457,7 +457,7 @@ class PropertyExample: StringSpec() {
 
     "String size" {
       forAll(2300) { a: String, b: String ->
-        (a + b).length shouldBe a.length + b.length
+        (a + b).length == a.length + b.length
       }
     }
 


### PR DESCRIPTION
forAll() expects that passed lambda returns Boolean, not Unit