### PR TITLE
Make new `compare` helper private.

### DIFF
--- a/kotlintest-assertions/src/main/kotlin/io/kotlintest/dsl.kt
+++ b/kotlintest-assertions/src/main/kotlin/io/kotlintest/dsl.kt
@@ -13,7 +13,7 @@ fun fail(msg: String): Nothing = throw AssertionError(msg)
 
 // -- equality functions
 
-fun compare(a: Any?, b: Any?): Boolean {
+private fun compare(a: Any?, b: Any?): Boolean {
   return when (a) {
     is Int -> when (b) {
       is Long -> a.toLong() == b


### PR DESCRIPTION
This probably wasn't supposed to be in the global namespace.