### PR TITLE
Fix deprecation warning

### DIFF
--- a/kotlintest-assertions/src/main/kotlin/io/kotlintest/dsl.kt
+++ b/kotlintest-assertions/src/main/kotlin/io/kotlintest/dsl.kt
@@ -1,7 +1,6 @@
 package io.kotlintest
 
 import io.kotlintest.matchers.ToleranceMatcher
-import io.kotlintest.matchers.shouldBe
 import org.junit.ComparisonCompactor
 
 fun <T> be(expected: T) = equalityMatcher(expected)


### PR DESCRIPTION
We don't need to import the depreacted `shouldBe`, since it just forwards back to io.kotlintest.shouldBe.