### PR TITLE
Allow nullable arguments to more matcher functions.

### DIFF
--- a/kotlintest-assertions/src/main/kotlin/io/kotlintest/dsl.kt
+++ b/kotlintest-assertions/src/main/kotlin/io/kotlintest/dsl.kt
@@ -73,11 +73,11 @@ infix fun <T> T.should(matcher: (T) -> Unit) = matcher(this)
 
 // -- specialized overrides of shouldBe --
 
-infix fun Double.shouldBe(other: Double) = should(ToleranceMatcher(other, 0.0))
+infix fun Double?.shouldBe(other: Double?) = should(ToleranceMatcher(other, 0.0))
 
 // https://stackoverflow.com/questions/10934743/formatting-output-so-that-intellij-idea-shows-diffs-for-two-texts
 // https://github.com/JetBrains/intellij-community/blob/3f7e93e20b7e79ba389adf593b3b59e46a3e01d1/plugins/testng/src/com/theoryinpractice/testng/model/TestProxy.java#L50
-infix fun String.shouldBe(other: String) {
+infix fun String?.shouldBe(other: String?) {
   if (this != other) {
     throw AssertionError(ComparisonCompactor.getMessage(other, this))
   }

--- a/kotlintest-assertions/src/main/kotlin/io/kotlintest/matchers/DoubleMatchers.kt
+++ b/kotlintest-assertions/src/main/kotlin/io/kotlintest/matchers/DoubleMatchers.kt
@@ -26,10 +26,11 @@ fun between(a: Double, b: Double, tolerance: Double): Matcher<Double> = object :
   }
 }
 
-class ToleranceMatcher(private val expected: Double, private val tolerance: Double) : Matcher<Double> {
-
-  override fun test(value: Double): Result {
-    return if (Double.NaN == expected && Double.NaN == value) {
+class ToleranceMatcher(private val expected: Double?, private val tolerance: Double) : Matcher<Double?> {
+  override fun test(value: Double?): Result {
+    return if(value == null || expected == null) {
+      Result(value == expected, "$value should be equal to $expected", "$value should not be equal to $expected")
+    } else if (Double.NaN == expected && Double.NaN == value) {
       println("[WARN] By design, Double.Nan != Double.Nan; see https://stackoverflow.com/questions/8819738/why-does-double-nan-double-nan-return-false/8819776#8819776")
       Result(false,
           "By design, Double.Nan != Double.Nan; see https://stackoverflow.com/questions/8819738/why-does-double-nan-double-nan-return-false/8819776#8819776",
@@ -42,6 +43,4 @@ class ToleranceMatcher(private val expected: Double, private val tolerance: Doub
       Result(diff <= tolerance, "$value should be equal to $expected", "$value should not be equal to $expected")
     }
   }
-
-  infix fun plusOrMinus(tolerance: Double): ToleranceMatcher = ToleranceMatcher(expected, tolerance)
 }

--- a/kotlintest-assertions/src/main/kotlin/io/kotlintest/matchers/types/matchers.kt
+++ b/kotlintest-assertions/src/main/kotlin/io/kotlintest/matchers/types/matchers.kt
@@ -29,8 +29,8 @@ inline fun <reified T : Any> Any.shouldNotBeTypeOf() {
   this shouldNotBe matcher
 }
 
-fun Any.shouldBeSameInstanceAs(ref: Any) = this should beTheSameInstanceAs(ref)
-fun Any.shouldNotBeSameInstanceAs(ref: Any) = this shouldNotBe beTheSameInstanceAs(ref)
+fun Any?.shouldBeSameInstanceAs(ref: Any?) = this should beTheSameInstanceAs(ref)
+fun Any?.shouldNotBeSameInstanceAs(ref: Any?) = this shouldNotBe beTheSameInstanceAs(ref)
 
 inline fun <A, reified T : Annotation> Class<A>.shouldHaveAnnotation(klass: Class<T>) = this should haveAnnotation<A, T>(klass)
 

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/matchers/numerics/DoubleMatchersTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/matchers/numerics/DoubleMatchersTest.kt
@@ -29,6 +29,12 @@ class DoubleMatchersTest : ShouldSpec() {
       1.0 shouldBe 1.0
     }
 
+    should("accept nullable arguments") {
+      val l: Double? = 1.0
+      val r: Double? = 1.0
+      l shouldBe r
+    }
+
     should("match exactly") {
       1.0 shouldBe exactly(1.0)
       shouldThrow<AssertionError> {

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/matchers/types/TypeMatchersTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/matchers/types/TypeMatchersTest.kt
@@ -1,5 +1,7 @@
 package com.sksamuel.kotlintest.matchers.types
 
+import com.sksamuel.kotlintest.extensions.Numbers.a
+import com.sksamuel.kotlintest.extensions.Numbers.b
 import io.kotlintest.matchers.beInstanceOf
 import io.kotlintest.matchers.beOfType
 import io.kotlintest.matchers.beTheSameInstanceAs
@@ -80,9 +82,9 @@ class TypeMatchersTest : WordSpec() {
 
     "TypeMatchers.theSameInstanceAs" should {
       "test that references are equal" {
-        val b = listOf(1, 2, 3)
-        val a = b
-        val c = listOf(1, 2, 3)
+        val b: List<Int>? = listOf(1, 2, 3)
+        val a: List<Int>? = b
+        val c: List<Int>? = listOf(1, 2, 3)
 
         a should beTheSameInstanceAs(b)
         a.shouldBeSameInstanceAs(b)


### PR DESCRIPTION
In the case of the Double and String matchers, nullable arguments would
use the generic overload in some cases. This would compile, but would not produce the
expected results.