### PR TITLE
Allow nullable receivers for string matchers.

### DIFF
--- a/kotlintest-assertions/src/main/kotlin/io/kotlintest/matchers/StringMatchers.kt
+++ b/kotlintest-assertions/src/main/kotlin/io/kotlintest/matchers/StringMatchers.kt
@@ -4,47 +4,49 @@ import convertValueToString
 import io.kotlintest.Matcher
 import io.kotlintest.Result
 import io.kotlintest.matchers.string.include
+import io.kotlintest.neverNullMatcher
+import kotlin.math.min
 
-fun startWith(prefix: String): Matcher<String> = object : Matcher<String> {
-  override fun test(value: String): Result {
-    val ok = value.startsWith(prefix)
-    var msg = "${convertValueToString(value)} should start with $prefix"
-    val notmsg = "${convertValueToString(value)} should not start with $prefix"
-    if (!ok) {
-      for (k in 0 until Math.min(value.length, prefix.length)) {
-        if (value[k] != prefix[k]) {
-          msg = "$msg (diverged at index $k)"
-          break
-        }
+fun startWith(prefix: String) = neverNullMatcher<String> { value ->
+  val ok = value.startsWith(prefix)
+  var msg = "${convertValueToString(value)} should start with $prefix"
+  val notmsg = "${convertValueToString(value)} should not start with $prefix"
+  if (!ok) {
+    for (k in 0 until min(value.length, prefix.length)) {
+      if (value[k] != prefix[k]) {
+        msg = "$msg (diverged at index $k)"
+        break
       }
     }
-    return Result(ok, msg, notmsg)
   }
+  Result(ok, msg, notmsg)
 }
 
 fun haveSubstring(substr: String) = include(substr)
 @Deprecated("use should include(substring)", ReplaceWith("include(substr)", "io.kotlintest.matchers.string.include"))
 fun substring(substr: String) = include(substr)
 
-fun endWith(suffix: String): Matcher<String> = object : Matcher<String> {
-  override fun test(value: String) = Result(value.endsWith(suffix),
+fun endWith(suffix: String) = neverNullMatcher<String> { value ->
+  Result(
+      value.endsWith(suffix),
       "${convertValueToString(value)} should end with $suffix",
       "${convertValueToString(value)} should not end with $suffix")
 }
 
-fun match(regex: Regex): Matcher<String> = object : Matcher<String> {
-  override fun test(value: String) = Result(
+fun match(regex: Regex) = neverNullMatcher<String> { value ->
+  Result(
       value.matches(regex),
       "${convertValueToString(value)} should match regex $regex",
       "${convertValueToString(value)} should not match regex $regex")
 }
 
-fun match(regex: String): Matcher<String> = match(regex.toRegex())
+fun match(regex: String): Matcher<String?> = match(regex.toRegex())
 
-fun strlen(length: Int): Matcher<String> = haveLength(length)
+fun strlen(length: Int): Matcher<String?> = haveLength(length)
 
-fun haveLength(length: Int): Matcher<String> = object : Matcher<String> {
-  override fun test(value: String) = Result(value.length == length,
+fun haveLength(length: Int) = neverNullMatcher<String> { value ->
+  Result(
+      value.length == length,
       "${convertValueToString(value)} should have length $length",
       "${convertValueToString(value)} should not have length $length")
 }

--- a/kotlintest-assertions/src/main/kotlin/io/kotlintest/matchers/string/matchers.kt
+++ b/kotlintest-assertions/src/main/kotlin/io/kotlintest/matchers/string/matchers.kt
@@ -1,163 +1,160 @@
 package io.kotlintest.matchers.string
 
 import convertValueToString
-import io.kotlintest.Matcher
 import io.kotlintest.Result
 import io.kotlintest.matchers.endWith
 import io.kotlintest.matchers.haveLength
 import io.kotlintest.matchers.match
 import io.kotlintest.matchers.startWith
+import io.kotlintest.neverNullMatcher
 import io.kotlintest.should
 import io.kotlintest.shouldNot
 
-fun String.shouldContainOnlyDigits() = this should containOnlyDigits()
-fun String.shouldNotContainOnlyDigits() = this shouldNot containOnlyDigits()
-fun containOnlyDigits() = object : Matcher<String> {
-  override fun test(value: String): Result {
-    val passed = value.chars().allMatch { Character.isDigit(it) }
-    return Result(passed, "${convertValueToString(value)} should contain only digits", "${convertValueToString(value)} should not contain only digits")
-  }
+fun String?.shouldContainOnlyDigits() = this should containOnlyDigits()
+fun String?.shouldNotContainOnlyDigits() = this shouldNot containOnlyDigits()
+fun containOnlyDigits() = neverNullMatcher<String> { value ->
+  Result(
+      value.chars().allMatch { Character.isDigit(it) },
+      "${convertValueToString(value)} should contain only digits",
+      "${convertValueToString(value)} should not contain only digits")
 }
 
-fun String.shouldContainADigit() = this should containADigit()
-fun String.shouldNotContainADigit() = this shouldNot containADigit()
-fun containADigit() = object : Matcher<String> {
-  override fun test(value: String): Result {
-    val passed = value.chars().anyMatch { Character.isDigit(it) }
-    return Result(passed, "${convertValueToString(value)} should contain at least one digits", "${convertValueToString(value)} should not contain any digits")
-  }
+fun String?.shouldContainADigit() = this should containADigit()
+fun String?.shouldNotContainADigit() = this shouldNot containADigit()
+fun containADigit() = neverNullMatcher<String> { value ->
+  Result(
+      value.chars().anyMatch { Character.isDigit(it) },
+      "${convertValueToString(value)} should contain at least one digit",
+      "${convertValueToString(value)} should not contain any digits")
 }
 
-fun String.shouldContainOnlyOnce(substr: String) = this should containOnlyOnce(substr)
-fun String.shouldNotContainOnlyOnce(substr: String) = this shouldNot containOnlyOnce(substr)
-fun containOnlyOnce(substring: String) = object : Matcher<String> {
-  override fun test(value: String): Result {
-    val passed = value.indexOf(substring) == value.lastIndexOf(substring)
-    return Result(passed,
-        "${convertValueToString(value)} should contain the substring ${convertValueToString(substring)} only once",
-        "${convertValueToString(value)} should not contain the substring ${convertValueToString(substring)} exactly once"
-    )
-  }
+fun String?.shouldContainOnlyOnce(substr: String) = this should containOnlyOnce(substr)
+fun String?.shouldNotContainOnlyOnce(substr: String) = this shouldNot containOnlyOnce(substr)
+fun containOnlyOnce(substring: String) = neverNullMatcher<String> { value ->
+  Result(
+      value.indexOf(substring) == value.lastIndexOf(substring),
+      "${convertValueToString(value)} should contain the substring ${convertValueToString(substring)} exactly once",
+      "${convertValueToString(value)} should not contain the substring ${convertValueToString(substring)} exactly once"
+  )
 }
 
-fun String.shouldBeLowerCase() = this should beLowerCase()
-fun String.shouldNotBeLowerCase() = this shouldNot beLowerCase()
-fun beLowerCase() = object : Matcher<String> {
-  override fun test(value: String): Result {
-    val passed = value.toLowerCase() == value
-    return Result(passed, "${convertValueToString(value)} should be lower case",
-        "${convertValueToString(value)} should not should be lower case")
-  }
+fun String?.shouldBeLowerCase() = this should beLowerCase()
+fun String?.shouldNotBeLowerCase() = this shouldNot beLowerCase()
+fun beLowerCase() = neverNullMatcher<String> { value ->
+  Result(
+      value.toLowerCase() == value,
+      "${convertValueToString(value)} should be lower case",
+      "${convertValueToString(value)} should not should be lower case")
 }
 
-fun String.shouldBeUpperCase() = this should beUpperCase()
-fun String.shouldNotBeUpperCase() = this shouldNot beUpperCase()
-fun beUpperCase() = object : Matcher<String> {
-  override fun test(value: String): Result {
-    val passed = value.toUpperCase() == value
-    return Result(passed, "${convertValueToString(value)} should be upper case",
-        "${convertValueToString(value)} should not should be upper case")
-  }
+fun String?.shouldBeUpperCase() = this should beUpperCase()
+fun String?.shouldNotBeUpperCase() = this shouldNot beUpperCase()
+fun beUpperCase() = neverNullMatcher<String> { value ->
+  Result(
+      value.toUpperCase() == value,
+      "${convertValueToString(value)} should be upper case",
+      "${convertValueToString(value)} should not should be upper case")
 }
 
-fun String.shouldBeEmpty() = this should beEmpty()
-fun String.shouldNotBeEmpty() = this shouldNot beEmpty()
-fun beEmpty() = object : Matcher<String> {
-  override fun test(value: String): Result {
-    return Result(value.isEmpty(), "${convertValueToString(value)} should be empty",
-        "${convertValueToString(value)} should not be empty")
-  }
+fun String?.shouldBeEmpty() = this should beEmpty()
+fun String?.shouldNotBeEmpty() = this shouldNot beEmpty()
+fun beEmpty() = neverNullMatcher<String> { value ->
+  Result(
+      value.isEmpty(),
+      "${convertValueToString(value)} should be empty",
+      "${convertValueToString(value)} should not be empty")
 }
 
-fun String.shouldHaveSameLengthAs(other: String) = this should haveSameLengthAs(other)
-fun String.shouldNotHaveSameLengthAs(other: String) = this shouldNot haveSameLengthAs(other)
-fun haveSameLengthAs(other: String) = object : Matcher<String> {
-  override fun test(value: String): Result {
-    return Result(value.length == other.length,
-        "${convertValueToString(value)} should have the same length as ${convertValueToString(other)}",
-        "${convertValueToString(value)} should not have the same length as ${convertValueToString(other)}")
-  }
+fun String?.shouldHaveSameLengthAs(other: String) = this should haveSameLengthAs(other)
+fun String?.shouldNotHaveSameLengthAs(other: String) = this shouldNot haveSameLengthAs(other)
+fun haveSameLengthAs(other: String) = neverNullMatcher<String> { value ->
+  Result(
+      value.length == other.length,
+      "${convertValueToString(value)} should have the same length as ${convertValueToString(other)}",
+      "${convertValueToString(value)} should not have the same length as ${convertValueToString(other)}")
 }
 
-fun String.shouldHaveLineCount(count: Int) = this should haveLineCount(count)
-fun String.shouldNotHaveLineCount(count: Int) = this shouldNot haveLineCount(count)
-fun haveLineCount(count: Int) = object : Matcher<String> {
-  override fun test(value: String): Result {
-    val lines = value.split(System.lineSeparator()).size
-    return Result(lines == count,
-        "${convertValueToString(value)} should have $count lines but had $lines",
-        "${convertValueToString(value)} should not have $count lines")
-  }
+fun String?.shouldHaveLineCount(count: Int) = this should haveLineCount(count)
+fun String?.shouldNotHaveLineCount(count: Int) = this shouldNot haveLineCount(count)
+/**
+ * Match on the number of newlines in a string.
+ *
+ * This will count both "\n" and "\r\n", and so is not dependant on the system line separator.
+ */
+fun haveLineCount(count: Int) = neverNullMatcher<String> { value ->
+  val lines = value.count { it == '\n' }
+  Result(lines == count,
+      "${convertValueToString(value)} should have $count lines but had $lines",
+      "${convertValueToString(value)} should not have $count lines")
 }
 
-fun String.shouldBeBlank() = this should beBlank()
-fun String.shouldNotBeBlank() = this shouldNot beBlank()
+fun String?.shouldBeBlank() = this should beBlank()
+fun String?.shouldNotBeBlank() = this shouldNot beBlank()
 fun containOnlyWhitespace() = beBlank()
-fun beBlank() = object : Matcher<String> {
-  override fun test(value: String): Result {
-    return Result(value.isBlank(),
-        "${convertValueToString(value)} should contain only whitespace",
-        "${convertValueToString(value)} should not contain only whitespace")
-  }
+fun beBlank() = neverNullMatcher<String> { value ->
+  Result(
+      value.isBlank(),
+      "${convertValueToString(value)} should contain only whitespace",
+      "${convertValueToString(value)} should not contain only whitespace")
 }
 
-fun String.shouldContainIgnoringCase(substr: String) = this should containIgnoringCase(substr)
-fun String.shouldNotContainIgnoringCase(substr: String) = this shouldNot containIgnoringCase(substr)
-fun containIgnoringCase(substr: String) = object : Matcher<String> {
-  override fun test(value: String): Result {
-    val passed = value.toLowerCase().indexOf(substr.toLowerCase()) >= 0
-    return Result(passed,
-        "${convertValueToString(value)} should contain the substring ${convertValueToString(substr)} (case insensitive)",
-        "${convertValueToString(value)} should not contain the substring ${convertValueToString(substr)} (case insensitive)")
-  }
+fun String?.shouldContainIgnoringCase(substr: String) = this should containIgnoringCase(substr)
+fun String?.shouldNotContainIgnoringCase(substr: String) = this shouldNot containIgnoringCase(substr)
+fun containIgnoringCase(substr: String) = neverNullMatcher<String> { value ->
+  Result(
+      value.toLowerCase().indexOf(substr.toLowerCase()) >= 0,
+      "${convertValueToString(value)} should contain the substring ${convertValueToString(substr)} (case insensitive)",
+      "${convertValueToString(value)} should not contain the substring ${convertValueToString(substr)} (case insensitive)")
 }
 
-fun String.shouldContain(regex: Regex) = this should contain(regex)
-fun String.shouldNotContain(regex: Regex) = this shouldNot contain(regex)
-fun contain(regex: Regex) = object : Matcher<String> {
-  override fun test(value: String): Result {
-    val passed = value.contains(regex)
-    return Result(passed,
-        "${convertValueToString(value)} should contain regex $regex",
-        "${convertValueToString(value)} should not contain regex $regex")
-  }
+fun String?.shouldContain(regex: Regex) = this should contain(regex)
+fun String?.shouldNotContain(regex: Regex) = this shouldNot contain(regex)
+fun contain(regex: Regex) = neverNullMatcher<String> { value ->
+  Result(
+      value.contains(regex),
+      "${convertValueToString(value)} should contain regex $regex",
+      "${convertValueToString(value)} should not contain regex $regex")
 }
 
-fun String.shouldContain(substr: String) = this should contain(substr)
-fun String.shouldNotContain(substr: String) = this shouldNot contain(substr)
+fun String?.shouldContain(substr: String) = this should contain(substr)
+fun String?.shouldNotContain(substr: String) = this shouldNot contain(substr)
 fun contain(substr: String) = include(substr)
 
-fun String.shouldInclude(substr: String) = this should include(substr)
-fun String.shouldNotInclude(substr: String) = this shouldNot include(substr)
-fun include(substr: String): Matcher<String> = object : Matcher<String> {
-  override fun test(value: String): Result {
-    val passed = value.contains(substr)
-    return Result(passed,
-        "${convertValueToString(value)} should include substring ${convertValueToString(substr)}",
-        "$value should not include substring ${convertValueToString(substr)}")
-  }
+fun String?.shouldInclude(substr: String) = this should include(substr)
+fun String?.shouldNotInclude(substr: String) = this shouldNot include(substr)
+fun include(substr: String) = neverNullMatcher<String> { value ->
+  Result(
+      value.contains(substr),
+      "${convertValueToString(value)} should include substring ${convertValueToString(substr)}",
+      "$value should not include substring ${convertValueToString(substr)}")
 }
 
-fun String.shouldHaveMaxLength(length: Int) = this should haveMaxLength(length)
-fun String.shouldNotHaveMaxLength(length: Int) = this shouldNot haveMaxLength(length)
+fun String?.shouldHaveMaxLength(length: Int) = this should haveMaxLength(length)
+fun String?.shouldNotHaveMaxLength(length: Int) = this shouldNot haveMaxLength(length)
 
-fun haveMaxLength(length: Int): Matcher<String> = object : Matcher<String> {
-  override fun test(value: String) = Result(value.length >= length, "${convertValueToString(value)} should have maximum length of $length", "${convertValueToString(value)} should have minimum length of ${length - 1}")
+fun haveMaxLength(length: Int) = neverNullMatcher<String> { value ->
+  Result(
+      value.length <= length,
+      "${convertValueToString(value)} should have maximum length of $length",
+      "${convertValueToString(value)} should have minimum length of ${length - 1}")
 }
 
-fun String.shouldHaveMinLength(length: Int) = this should haveMinLength(length)
-fun String.shouldNotHaveMinLength(length: Int) = this shouldNot haveMinLength(length)
+fun String?.shouldHaveMinLength(length: Int) = this should haveMinLength(length)
+fun String?.shouldNotHaveMinLength(length: Int) = this shouldNot haveMinLength(length)
 
-fun haveMinLength(length: Int): Matcher<String> = object : Matcher<String> {
-  override fun test(value: String) = Result(value.length >= length, "${convertValueToString(value)} should have minimum length of $length", "${convertValueToString(value)} should have maximum length of ${length - 1}")
+fun haveMinLength(length: Int) = neverNullMatcher<String> { value ->
+  Result(
+      value.length >= length,
+      "${convertValueToString(value)} should have minimum length of $length",
+      "${convertValueToString(value)} should have maximum length of ${length - 1}")
 }
 
-fun String.shouldHaveLength(length: Int) = this should haveLength(length)
-fun String.shouldNotHaveLength(length: Int) = this shouldNot haveLength(length)
-fun String.shouldMatch(regex: String) = this should match(regex)
-fun String.shouldMatch(regex: Regex) = this should match(regex)
-fun String.shouldNotMatch(regex: String) = this shouldNot match(regex)
-fun String.shouldEndWith(suffix: String) = this should endWith(suffix)
-fun String.shouldNotEndWith(suffix: String) = this shouldNot endWith(suffix)
-fun String.shouldStartWith(suffix: String) = this should startWith(suffix)
-fun String.shouldNotStartWith(suffix: String) = this shouldNot startWith(suffix)
+fun String?.shouldHaveLength(length: Int) = this should haveLength(length)
+fun String?.shouldNotHaveLength(length: Int) = this shouldNot haveLength(length)
+fun String?.shouldMatch(regex: String) = this should match(regex)
+fun String?.shouldMatch(regex: Regex) = this should match(regex)
+fun String?.shouldNotMatch(regex: String) = this shouldNot match(regex)
+fun String?.shouldEndWith(suffix: String) = this should endWith(suffix)
+fun String?.shouldNotEndWith(suffix: String) = this shouldNot endWith(suffix)
+fun String?.shouldStartWith(suffix: String) = this should startWith(suffix)
+fun String?.shouldNotStartWith(suffix: String) = this shouldNot startWith(suffix)

--- a/kotlintest-extensions/kotlintest-extensions-spring/src/test/kotlin/io/kotlintest/spring/SpringListenerTest.kt
+++ b/kotlintest-extensions/kotlintest-extensions-spring/src/test/kotlin/io/kotlintest/spring/SpringListenerTest.kt
@@ -16,7 +16,7 @@ class SpringListenerTest : WordSpec() {
   init {
     "SpringListener" should {
       "have autowired the service" {
-        service!!.repository.findUser().name shouldBe "system_user"
+        service?.repository?.findUser()?.name shouldBe "system_user"
       }
     }
   }

--- a/kotlintest-runner/kotlintest-runner-junit5/src/main/kotlin/io/kotlintest/specs/specs.kt
+++ b/kotlintest-runner/kotlintest-runner-junit5/src/main/kotlin/io/kotlintest/specs/specs.kt
@@ -34,5 +34,5 @@ abstract class StringSpec(body: AbstractStringSpec.() -> Unit = {}) : AbstractSt
 abstract class WordSpec(body: AbstractWordSpec.() -> Unit = {}) : AbstractWordSpec(body), IntelliMarker {
   // need to overload this so that when doing "string" should haveLength(5) in a word spec, we don't
   // clash with the other should method
-  infix fun String.should(matcher: Matcher<String>) = this shouldMatch matcher
+  infix fun String?.should(matcher: Matcher<String?>) = this shouldMatch matcher
 }

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/matchers/file/FileMatchersTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/matchers/file/FileMatchersTest.kt
@@ -85,11 +85,11 @@ class FileMatchersTest : FunSpec() {
 
       shouldThrow<AssertionError> {
         file should haveExtension(".jpeg")
-      }.message!!.shouldEndWith("with one of .jpeg")
+      }.message.shouldEndWith("with one of .jpeg")
 
       shouldThrow<AssertionError> {
         file.shouldHaveExtension(".jpeg")
-      }.message!!.shouldEndWith("with one of .jpeg")
+      }.message.shouldEndWith("with one of .jpeg")
 
       file.shouldHaveExtension(".test")
       file.shouldNotHaveExtension(".wibble")

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/matchers/string/StringMatchersTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/matchers/string/StringMatchersTest.kt
@@ -2,47 +2,10 @@ package com.sksamuel.kotlintest.matchers.string
 
 import io.kotlintest.matchers.endWith
 import io.kotlintest.matchers.haveLength
+import io.kotlintest.matchers.haveSubstring
 import io.kotlintest.matchers.match
 import io.kotlintest.matchers.startWith
-import io.kotlintest.matchers.string.beBlank
-import io.kotlintest.matchers.string.beEmpty
-import io.kotlintest.matchers.string.beLowerCase
-import io.kotlintest.matchers.string.beUpperCase
-import io.kotlintest.matchers.string.contain
-import io.kotlintest.matchers.string.containADigit
-import io.kotlintest.matchers.string.containIgnoringCase
-import io.kotlintest.matchers.string.containOnlyDigits
-import io.kotlintest.matchers.string.containOnlyOnce
-import io.kotlintest.matchers.string.haveSameLengthAs
-import io.kotlintest.matchers.string.include
-import io.kotlintest.matchers.string.shouldBeBlank
-import io.kotlintest.matchers.string.shouldBeEmpty
-import io.kotlintest.matchers.string.shouldBeLowerCase
-import io.kotlintest.matchers.string.shouldBeUpperCase
-import io.kotlintest.matchers.string.shouldContain
-import io.kotlintest.matchers.string.shouldContainADigit
-import io.kotlintest.matchers.string.shouldContainIgnoringCase
-import io.kotlintest.matchers.string.shouldContainOnlyDigits
-import io.kotlintest.matchers.string.shouldEndWith
-import io.kotlintest.matchers.string.shouldHaveLength
-import io.kotlintest.matchers.string.shouldHaveSameLengthAs
-import io.kotlintest.matchers.string.shouldInclude
-import io.kotlintest.matchers.string.shouldMatch
-import io.kotlintest.matchers.string.shouldNotBeBlank
-import io.kotlintest.matchers.string.shouldNotBeEmpty
-import io.kotlintest.matchers.string.shouldNotBeLowerCase
-import io.kotlintest.matchers.string.shouldNotBeUpperCase
-import io.kotlintest.matchers.string.shouldNotContain
-import io.kotlintest.matchers.string.shouldNotContainADigit
-import io.kotlintest.matchers.string.shouldNotContainIgnoringCase
-import io.kotlintest.matchers.string.shouldNotContainOnlyDigits
-import io.kotlintest.matchers.string.shouldNotContainOnlyOnce
-import io.kotlintest.matchers.string.shouldNotEndWith
-import io.kotlintest.matchers.string.shouldNotHaveLength
-import io.kotlintest.matchers.string.shouldNotHaveSameLengthAs
-import io.kotlintest.matchers.string.shouldNotMatch
-import io.kotlintest.matchers.string.shouldNotStartWith
-import io.kotlintest.matchers.string.shouldStartWith
+import io.kotlintest.matchers.string.*
 import io.kotlintest.should
 import io.kotlintest.shouldBe
 import io.kotlintest.shouldNot
@@ -58,17 +21,34 @@ class StringMatchersTest : FreeSpec() {
           "la tour eiffel" shouldBe "la tour tower london"
         }.message shouldBe "expected:<la tour [tower london]> but was:<la tour [eiffel]>"
       }
+
+      "should support null arguments" {
+        val a: String? = "a"
+        val b: String? = "a"
+        a shouldBe b
+      }
     }
 
     "contain only once" {
       "la tour" should containOnlyOnce("tour")
-      "la tour".shouldContain("tour")
       "la tour tour" shouldNot containOnlyOnce("tour")
       "la tour tour".shouldNotContainOnlyOnce("tour")
 
       shouldThrow<AssertionError> {
-        "la tour".shouldContain("wibble")
-      }.message shouldBe "la tour should include substring wibble"
+        null shouldNot containOnlyOnce("tour")
+      }.message shouldBe "Expecting actual not to be null"
+
+      shouldThrow<AssertionError> {
+        null.shouldNotContainOnlyOnce("tour")
+      }.message shouldBe "Expecting actual not to be null"
+
+      shouldThrow<AssertionError> {
+        null should containOnlyOnce("tour")
+      }.message shouldBe "Expecting actual not to be null"
+
+      shouldThrow<AssertionError> {
+        null.shouldContainOnlyOnce("tour")
+      }.message shouldBe "Expecting actual not to be null"
     }
 
     "contain(regex)" {
@@ -85,6 +65,22 @@ class StringMatchersTest : FreeSpec() {
       shouldThrow<AssertionError> {
         "la tour".shouldNotContain("^.*?tour$".toRegex())
       }.message shouldBe "la tour should not contain regex ^.*?tour\$"
+
+      shouldThrow<AssertionError> {
+        null shouldNot contain("^.*?tour$".toRegex())
+      }.message shouldBe "Expecting actual not to be null"
+
+      shouldThrow<AssertionError> {
+        null.shouldNotContain("^.*?tour$".toRegex())
+      }.message shouldBe "Expecting actual not to be null"
+
+      shouldThrow<AssertionError> {
+        null should contain("^.*?tour$".toRegex())
+      }.message shouldBe "Expecting actual not to be null"
+
+      shouldThrow<AssertionError> {
+        null.shouldContain("^.*?tour$".toRegex())
+      }.message shouldBe "Expecting actual not to be null"
     }
 
     "string should contain" - {
@@ -94,6 +90,11 @@ class StringMatchersTest : FreeSpec() {
         "hello" should include("ell")
         "hello" should include("hello")
         "hello" should include("")
+        "la tour".shouldContain("tour")
+
+        shouldThrow<AssertionError> {
+          "la tour".shouldContain("wibble")
+        }.message shouldBe "la tour should include substring wibble"
 
         shouldThrow<AssertionError> {
           "hello" should include("allo")
@@ -102,6 +103,36 @@ class StringMatchersTest : FreeSpec() {
         shouldThrow<AssertionError> {
           "hello".shouldInclude("qwe")
         }.message shouldBe "hello should include substring qwe"
+      }
+
+      "should fail if value is null" {
+        shouldThrow<AssertionError> {
+          null shouldNot include("allo")
+        }.message shouldBe "Expecting actual not to be null"
+
+        shouldThrow<AssertionError> {
+          null.shouldNotInclude("qwe")
+        }.message shouldBe "Expecting actual not to be null"
+
+        shouldThrow<AssertionError> {
+          null shouldNot contain("allo")
+        }.message shouldBe "Expecting actual not to be null"
+
+        shouldThrow<AssertionError> {
+          null.shouldNotContain("qwe")
+        }.message shouldBe "Expecting actual not to be null"
+
+        shouldThrow<AssertionError> {
+          null should include("allo")
+        }.message shouldBe "Expecting actual not to be null"
+
+        shouldThrow<AssertionError> {
+          null should haveSubstring("allo")
+        }.message shouldBe "Expecting actual not to be null"
+
+        shouldThrow<AssertionError> {
+          null.shouldInclude("qwe")
+        }.message shouldBe "Expecting actual not to be null"
       }
     }
 
@@ -119,7 +150,24 @@ class StringMatchersTest : FreeSpec() {
         shouldThrow<AssertionError> {
           "".shouldNotBeEmpty()
         }.message shouldBe "<empty string> should not be empty"
+      }
 
+      "should fail if value is null" {
+        shouldThrow<AssertionError> {
+          null shouldNot beEmpty()
+        }.message shouldBe "Expecting actual not to be null"
+
+        shouldThrow<AssertionError> {
+          null.shouldNotBeEmpty()
+        }.message shouldBe "Expecting actual not to be null"
+
+        shouldThrow<AssertionError> {
+          null should beEmpty()
+        }.message shouldBe "Expecting actual not to be null"
+
+        shouldThrow<AssertionError> {
+          null.shouldBeEmpty()
+        }.message shouldBe "Expecting actual not to be null"
       }
     }
 
@@ -134,7 +182,25 @@ class StringMatchersTest : FreeSpec() {
 
         shouldThrow<AssertionError> {
           "hello" should containADigit()
-        }.message shouldBe "hello should contain at least one digits"
+        }.message shouldBe "hello should contain at least one digit"
+      }
+
+      "should fail if value is null" {
+        shouldThrow<AssertionError> {
+          null shouldNot containADigit()
+        }.message shouldBe "Expecting actual not to be null"
+
+        shouldThrow<AssertionError> {
+          null.shouldNotContainADigit()
+        }.message shouldBe "Expecting actual not to be null"
+
+        shouldThrow<AssertionError> {
+          null should containADigit()
+        }.message shouldBe "Expecting actual not to be null"
+
+        shouldThrow<AssertionError> {
+          null.shouldContainADigit()
+        }.message shouldBe "Expecting actual not to be null"
       }
     }
 
@@ -147,6 +213,24 @@ class StringMatchersTest : FreeSpec() {
         "hello" shouldNot beUpperCase()
         "HELLO".shouldBeUpperCase()
         "HelLO".shouldNotBeUpperCase()
+      }
+
+      "should fail if value is null" {
+        shouldThrow<AssertionError> {
+          null shouldNot beUpperCase()
+        }.message shouldBe "Expecting actual not to be null"
+
+        shouldThrow<AssertionError> {
+          null.shouldNotBeUpperCase()
+        }.message shouldBe "Expecting actual not to be null"
+
+        shouldThrow<AssertionError> {
+          null should beUpperCase()
+        }.message shouldBe "Expecting actual not to be null"
+
+        shouldThrow<AssertionError> {
+          null.shouldBeUpperCase()
+        }.message shouldBe "Expecting actual not to be null"
       }
     }
 
@@ -161,17 +245,54 @@ class StringMatchersTest : FreeSpec() {
         "hello".shouldBeLowerCase()
         "HELLO".shouldNotBeLowerCase()
       }
+
+      "should fail if value is null" {
+        shouldThrow<AssertionError> {
+          null shouldNot beLowerCase()
+        }.message shouldBe "Expecting actual not to be null"
+
+        shouldThrow<AssertionError> {
+          null.shouldNotBeLowerCase()
+        }.message shouldBe "Expecting actual not to be null"
+
+        shouldThrow<AssertionError> {
+          null should beLowerCase()
+        }.message shouldBe "Expecting actual not to be null"
+
+        shouldThrow<AssertionError> {
+          null.shouldBeLowerCase()
+        }.message shouldBe "Expecting actual not to be null"
+      }
     }
 
 
     "string should beBlank()" - {
       "should test that a string has only whitespace" {
         "" should beBlank()
+        "" should containOnlyWhitespace()
         "     \t     " should beBlank()
         "hello" shouldNot beBlank()
 
         "hello".shouldNotBeBlank()
         "   ".shouldBeBlank()
+      }
+
+      "should fail if value is null" {
+        shouldThrow<AssertionError> {
+          null shouldNot beBlank()
+        }.message shouldBe "Expecting actual not to be null"
+
+        shouldThrow<AssertionError> {
+          null.shouldNotBeBlank()
+        }.message shouldBe "Expecting actual not to be null"
+
+        shouldThrow<AssertionError> {
+          null should beBlank()
+        }.message shouldBe "Expecting actual not to be null"
+
+        shouldThrow<AssertionError> {
+          null.shouldBeBlank()
+        }.message shouldBe "Expecting actual not to be null"
       }
     }
 
@@ -189,6 +310,24 @@ class StringMatchersTest : FreeSpec() {
         "qe".shouldNotHaveSameLengthAs("")
         "qe".shouldNotHaveSameLengthAs("fffff")
       }
+
+      "should fail if value is null" {
+        shouldThrow<AssertionError> {
+          null shouldNot haveSameLengthAs("")
+        }.message shouldBe "Expecting actual not to be null"
+
+        shouldThrow<AssertionError> {
+          null.shouldNotHaveSameLengthAs("")
+        }.message shouldBe "Expecting actual not to be null"
+
+        shouldThrow<AssertionError> {
+          null should haveSameLengthAs("o")
+        }.message shouldBe "Expecting actual not to be null"
+
+        shouldThrow<AssertionError> {
+          null.shouldHaveSameLengthAs("o")
+        }.message shouldBe "Expecting actual not to be null"
+      }
     }
 
     "string should containIgnoringCase(other)" - {
@@ -198,6 +337,24 @@ class StringMatchersTest : FreeSpec() {
 
         "hello".shouldContainIgnoringCase("HEllO")
         "hello".shouldNotContainIgnoringCase("hella")
+      }
+
+      "should fail if value is null" {
+        shouldThrow<AssertionError> {
+          null shouldNot containIgnoringCase("")
+        }.message shouldBe "Expecting actual not to be null"
+
+        shouldThrow<AssertionError> {
+          null.shouldNotContainIgnoringCase("")
+        }.message shouldBe "Expecting actual not to be null"
+
+        shouldThrow<AssertionError> {
+          null should containIgnoringCase("o")
+        }.message shouldBe "Expecting actual not to be null"
+
+        shouldThrow<AssertionError> {
+          null.shouldContainIgnoringCase("o")
+        }.message shouldBe "Expecting actual not to be null"
       }
     }
 
@@ -215,7 +372,7 @@ class StringMatchersTest : FreeSpec() {
       }
     }
 
-    "should endWith" -{
+    "should endWith" - {
       "should test strings" {
         "hello" should endWith("o")
         "hello" should endWith("")
@@ -230,6 +387,24 @@ class StringMatchersTest : FreeSpec() {
         shouldThrow<AssertionError> {
           "hello" should endWith("goodbye")
         }
+      }
+
+      "should fail if value is null" {
+        shouldThrow<AssertionError> {
+          null shouldNot endWith("")
+        }.message shouldBe "Expecting actual not to be null"
+
+        shouldThrow<AssertionError> {
+          null.shouldNotEndWith("")
+        }.message shouldBe "Expecting actual not to be null"
+
+        shouldThrow<AssertionError> {
+          null should endWith("o")
+        }.message shouldBe "Expecting actual not to be null"
+
+        shouldThrow<AssertionError> {
+          null.shouldEndWith("o")
+        }.message shouldBe "Expecting actual not to be null"
       }
     }
 
@@ -255,6 +430,23 @@ class StringMatchersTest : FreeSpec() {
           "la tour eiffel" should startWith("la tour tower london")
         }.message shouldBe "la tour eiffel should start with la tour tower london (diverged at index 8)"
       }
+      "should fail if value is null" {
+        shouldThrow<AssertionError> {
+          null should startWith("h")
+        }.message shouldBe "Expecting actual not to be null"
+
+        shouldThrow<AssertionError> {
+          null.shouldStartWith("")
+        }.message shouldBe "Expecting actual not to be null"
+
+        shouldThrow<AssertionError> {
+          null shouldNot startWith("h")
+        }.message shouldBe "Expecting actual not to be null"
+
+        shouldThrow<AssertionError> {
+          null.shouldNotStartWith("w")
+        }.message shouldBe "Expecting actual not to be null"
+      }
     }
 
     "should haveLength(5)" - {
@@ -277,17 +469,49 @@ class StringMatchersTest : FreeSpec() {
           "hello".shouldNotHaveLength(5)
         }.message shouldBe "hello should not have length 5"
       }
+      "should fail if value is null" {
+        shouldThrow<AssertionError> {
+          null should haveLength(0)
+        }.message shouldBe "Expecting actual not to be null"
+
+        shouldThrow<AssertionError> {
+          null should haveLength(0)
+        }.message shouldBe "Expecting actual not to be null"
+
+        shouldThrow<AssertionError> {
+          null shouldNot haveLength(0)
+        }.message shouldBe "Expecting actual not to be null"
+
+        shouldThrow<AssertionError> {
+          null.shouldNotHaveLength(0)
+        }.message shouldBe "Expecting actual not to be null"
+      }
     }
 
     "Matchers should end with x" - {
       "should fail if string does not end with x" {
-        val t = try {
+        "bibble" should endWith("ble")
+
+        shouldThrow<AssertionError> {
           "bibble" should endWith("qwe")
-          true
-        } catch (e: AssertionError) {
-          false
         }
-        t shouldBe false
+      }
+      "should fail if value is null" {
+        shouldThrow<AssertionError> {
+          null should endWith("")
+        }.message shouldBe "Expecting actual not to be null"
+
+        shouldThrow<AssertionError> {
+          null shouldNot endWith("")
+        }.message shouldBe "Expecting actual not to be null"
+
+        shouldThrow<AssertionError> {
+          null.shouldEndWith("")
+        }.message shouldBe "Expecting actual not to be null"
+
+        shouldThrow<AssertionError> {
+          null.shouldNotEndWith("")
+        }.message shouldBe "Expecting actual not to be null"
       }
     }
     "Matchers should have substring x" - {
@@ -297,13 +521,26 @@ class StringMatchersTest : FreeSpec() {
         "bibble" should include("bibble")
       }
       "should fail if string does not contains substring" {
-        val t = try {
+        shouldThrow<AssertionError> {
           "bibble" should include("qweqwe")
-          true
-        } catch (e: AssertionError) {
-          false
         }
-        t shouldBe false
+      }
+      "should fail if value is null" {
+        shouldThrow<AssertionError> {
+          null should include("")
+        }.message shouldBe "Expecting actual not to be null"
+
+        shouldThrow<AssertionError> {
+          null shouldNot include("")
+        }.message shouldBe "Expecting actual not to be null"
+
+        shouldThrow<AssertionError> {
+          null.shouldInclude("")
+        }.message shouldBe "Expecting actual not to be null"
+
+        shouldThrow<AssertionError> {
+          null.shouldNotInclude("")
+        }.message shouldBe "Expecting actual not to be null"
       }
     }
     "String should match regex" - {
@@ -316,8 +553,107 @@ class StringMatchersTest : FreeSpec() {
         "foo".shouldMatch("f..")
         "boo".shouldNotMatch("foo")
         "boo".shouldNotMatch("f..")
+      }
+      "should fail if value is null" {
+        shouldThrow<AssertionError> {
+          null should match("")
+        }.message shouldBe "Expecting actual not to be null"
 
+        shouldThrow<AssertionError> {
+          null shouldNot match("")
+        }.message shouldBe "Expecting actual not to be null"
 
+        shouldThrow<AssertionError> {
+          null.shouldMatch("")
+        }.message shouldBe "Expecting actual not to be null"
+
+        shouldThrow<AssertionError> {
+          null.shouldNotMatch("")
+        }.message shouldBe "Expecting actual not to be null"
+      }
+    }
+    "should have line count" - {
+      "should count all newlines" {
+        "" should haveLineCount(0)
+        "\n" should haveLineCount(1)
+        "\r\n" should haveLineCount(1)
+        "a\nb\nc" should haveLineCount(2)
+        "\r\n".shouldNotHaveLineCount(2)
+      }
+      "should fail if value is null" {
+        shouldThrow<AssertionError> {
+          null should haveLineCount(0)
+        }.message shouldBe "Expecting actual not to be null"
+
+        shouldThrow<AssertionError> {
+          null shouldNot haveLineCount(0)
+        }.message shouldBe "Expecting actual not to be null"
+
+        shouldThrow<AssertionError> {
+          null.shouldHaveLineCount(0)
+        }.message shouldBe "Expecting actual not to be null"
+
+        shouldThrow<AssertionError> {
+          null.shouldNotHaveLineCount(0)
+        }.message shouldBe "Expecting actual not to be null"
+      }
+    }
+    "should have min length" - {
+      "should check min length" {
+        "" should haveMinLength(0)
+        "1" should haveMinLength(1)
+        "123".shouldHaveMinLength(1)
+        "".shouldNotHaveMinLength(1)
+
+        shouldThrow<AssertionError> {
+          "1" should haveMinLength(2)
+        }.message shouldBe "1 should have minimum length of 2"
+      }
+      "should fail if value is null" {
+        shouldThrow<AssertionError> {
+          null should haveMinLength(0)
+        }.message shouldBe "Expecting actual not to be null"
+
+        shouldThrow<AssertionError> {
+          null shouldNot haveMinLength(0)
+        }.message shouldBe "Expecting actual not to be null"
+
+        shouldThrow<AssertionError> {
+          null.shouldHaveMinLength(0)
+        }.message shouldBe "Expecting actual not to be null"
+
+        shouldThrow<AssertionError> {
+          null.shouldNotHaveMinLength(0)
+        }.message shouldBe "Expecting actual not to be null"
+      }
+    }
+    "should have max length" - {
+      "should check max length" {
+        "" should haveMaxLength(0)
+        "1" should haveMaxLength(1)
+        "123".shouldHaveMaxLength(10)
+        "123".shouldNotHaveMaxLength(1)
+
+        shouldThrow<AssertionError> {
+          "12" should haveMaxLength(1)
+        }.message shouldBe "12 should have maximum length of 1"
+      }
+      "should fail if value is null" {
+        shouldThrow<AssertionError> {
+          null should haveMaxLength(0)
+        }.message shouldBe "Expecting actual not to be null"
+
+        shouldThrow<AssertionError> {
+          null shouldNot haveMaxLength(0)
+        }.message shouldBe "Expecting actual not to be null"
+
+        shouldThrow<AssertionError> {
+          null.shouldHaveMaxLength(0)
+        }.message shouldBe "Expecting actual not to be null"
+
+        shouldThrow<AssertionError> {
+          null.shouldNotHaveMaxLength(0)
+        }.message shouldBe "Expecting actual not to be null"
       }
     }
   }

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/properties/GenTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/properties/GenTest.kt
@@ -104,7 +104,7 @@ class GenTest : WordSpec() {
         )
 
         io.kotlintest.tables.forAll(table1) { clazz ->
-          Gen.forClassName(clazz).random().firstOrNull()!!.javaClass.name shouldBe clazz
+          Gen.forClassName(clazz).random().firstOrNull()?.javaClass?.name shouldBe clazz
         }
 
         val table2 = table(
@@ -118,10 +118,10 @@ class GenTest : WordSpec() {
 
         io.kotlintest.tables.forAll(table2) { clazz ->
           val tmp = clazz.split(".").last()
-          Gen.forClassName(clazz).random().firstOrNull()!!.javaClass.name shouldBe "java.lang.$tmp"
+          Gen.forClassName(clazz).random().firstOrNull()?.javaClass?.name shouldBe "java.lang.$tmp"
         }
 
-        Gen.forClassName("kotlin.Int").random().firstOrNull()!!.javaClass.name shouldBe "java.lang.Integer"
+        Gen.forClassName("kotlin.Int").random().firstOrNull()?.javaClass?.name shouldBe "java.lang.Integer"
       }
       "throw an exception, with a wrong class" {
         shouldThrow<IllegalArgumentException> {
@@ -180,7 +180,7 @@ class GenTest : WordSpec() {
 
         io.kotlintest.tables.forAll(table) { clazz ->
           val tmp = clazz.split(".")
-          Gen.forClassName(clazz).random().firstOrNull()!!.javaClass.name shouldHave include(tmp[tmp.size - 1])
+          Gen.forClassName(clazz).random().firstOrNull()?.javaClass?.name shouldHave include(tmp[tmp.size - 1])
         }
       }
       "throw an exeption, with a wrong class" {

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/properties/shrinking/ShrinkTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/properties/shrinking/ShrinkTest.kt
@@ -74,7 +74,7 @@ class ShrinkTest : StringSpec({
       }) { a ->
         a shouldBe lte(10)
       }
-    }.message!! shouldBe "Property failed for\nArg 0: 11 (shrunk from 14)\nafter 1 attempts\nCaused by: 14 should be <= 10"
+    }.message shouldBe "Property failed for\nArg 0: 11 (shrunk from 14)\nafter 1 attempts\nCaused by: 14 should be <= 10"
   }
 
   "should shrink strings to empty string" {

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/tables/TableTestingTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/tables/TableTestingTest.kt
@@ -148,9 +148,9 @@ class TableTestingTest : StringSpec() {
         }
       }.let {
         it.message shouldNotBe null
-        it.message!! should contain("1) Test failed for (name, sam) with error expected:<[christian]> but was:<[sam]>")
-        it.message!! should contain("2) Test failed for (name, billy) with error expected:<[christian]> but was:<[billy]>")
-        it.message!! shouldNot contain("3)")
+        it.message should contain("1) Test failed for (name, sam) with error expected:<[christian]> but was:<[sam]>")
+        it.message should contain("2) Test failed for (name, billy) with error expected:<[christian]> but was:<[billy]>")
+        it.message shouldNot contain("3)")
       }
     }
 
@@ -173,7 +173,7 @@ class TableTestingTest : StringSpec() {
     }
 
     "all exceptions should be grouped" {
-      shouldThrow<MultiAssertionError> {
+      shouldThrow<AssertionError> {
         val table1 = table(
             headers("name"),
             row(null),
@@ -185,9 +185,9 @@ class TableTestingTest : StringSpec() {
           it!! shouldNotBe "christian"
         }
       }.let {
-        it.message!! should contain("1) Test failed for (name, null) with error kotlin.KotlinNullPointerException")
-        it.message!! should contain("2) Test failed for (name, christian) with error christian should not equal christian")
-        it.message!! shouldNot contain("3)")
+        it.message should contain("1) Test failed for (name, null) with error kotlin.KotlinNullPointerException")
+        it.message should contain("2) Test failed for (name, christian) with error christian should not equal christian")
+        it.message shouldNot contain("3)")
       }
     }
   }


### PR DESCRIPTION
Allow nullable receivers for string matchers.

This PR allows receivers for string matchers to be of type `String?`. All matchers will fail if the actual string is null. Their inverses will also fail in the string is null. This matches assertj's behavior, and is, in my opinion, the least surprising behavior. (e.g. [1](https://github.com/joel-costigliola/assertj-core/blob/1bd10d9ee3845167c708cd2b984668f38da45544/src/main/java/org/assertj/core/internal/Strings.java#L624), [2](https://github.com/joel-costigliola/assertj-core/blob/1bd10d9ee3845167c708cd2b984668f38da45544/src/main/java/org/assertj/core/internal/Strings.java#L641))

This also adds at least one test for each string matcher and matcher extension, and fixes a couple of bugs in the matchers that didn't previously have coverage (e.g. `haveMaxLength` was checking `value.length >= length`, and `haveLineCount` would fail if the string used line separators that didn't match the current system))

Finally, this PR removes `!!` from tests that were using string assertions on nullable strings.