### PR TITLE
Remove duplicate kotlin gradle dependencies.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,6 @@ plugins {
 }
 
 allprojects {
-
     apply plugin: 'kotlin'
     apply plugin: 'java'
     apply plugin: 'maven'

--- a/kotlintest-assertions/build.gradle
+++ b/kotlintest-assertions/build.gradle
@@ -1,6 +1,3 @@
-ext.kotlin_version = '1.2.31'
-
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
 }

--- a/kotlintest-core/build.gradle
+++ b/kotlintest-core/build.gradle
@@ -1,5 +1,3 @@
-ext.kotlin_version = '1.2.31'
-
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     compile 'com.univocity:univocity-parsers:2.6.1'

--- a/kotlintest-samples/kotlintest-samples-gradle/build.gradle
+++ b/kotlintest-samples/kotlintest-samples-gradle/build.gradle
@@ -1,5 +1,15 @@
 apply plugin: 'org.junit.platform.gradle.plugin'
 
+buildscript {
+    ext.kotlin_version = '1.2.41'
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+    }
+}
+
 dependencies {
     testCompile 'io.kotlintest:kotlintest-runner-junit5:3.1.0'
 }

--- a/kotlintest-samples/kotlintest-samples-gradle/build.gradle
+++ b/kotlintest-samples/kotlintest-samples-gradle/build.gradle
@@ -1,15 +1,5 @@
 apply plugin: 'org.junit.platform.gradle.plugin'
 
-buildscript {
-    ext.kotlin_version = '1.2.31'
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-}
-
 dependencies {
     testCompile 'io.kotlintest:kotlintest-runner-junit5:3.1.0'
 }

--- a/kotlintest-samples/kotlintest-samples-spring/build.gradle
+++ b/kotlintest-samples/kotlintest-samples-spring/build.gradle
@@ -1,12 +1,7 @@
 apply plugin: 'org.junit.platform.gradle.plugin'
 
 buildscript {
-    ext.kotlin_version = '1.2.31'
-    repositories {
-        mavenCentral()
-    }
     dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.junit.platform:junit-platform-gradle-plugin:1.1.0"
     }
 }

--- a/kotlintest-samples/kotlintest-samples-spring/build.gradle
+++ b/kotlintest-samples/kotlintest-samples-spring/build.gradle
@@ -1,7 +1,12 @@
 apply plugin: 'org.junit.platform.gradle.plugin'
 
 buildscript {
+    ext.kotlin_version = '1.2.41'
+    repositories {
+        mavenCentral()
+    }
     dependencies {
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.junit.platform:junit-platform-gradle-plugin:1.1.0"
     }
 }


### PR DESCRIPTION
A number of submodules declared the kotlin buildscript dependency. This
is unnecessary, but not harmful. Additionally, some of the submodules
redeclared `ext.kotlin_version` to an older version of kotlin, which caused the 
reflect jar to be older than the stdlib in some cases.