### PR TITLE
Optimize sorted matcher

### DIFF
--- a/kotlintest-assertions/src/main/kotlin/io/kotlintest/matchers/CollectionMatchers.kt
+++ b/kotlintest-assertions/src/main/kotlin/io/kotlintest/matchers/CollectionMatchers.kt
@@ -82,12 +82,16 @@ fun <T> singleElement(t: T): Matcher<Collection<T>> = object : Matcher<Collectio
 fun <T : Comparable<T>> beSorted(): Matcher<List<T>> = sorted()
 fun <T : Comparable<T>> sorted(): Matcher<List<T>> = object : Matcher<List<T>> {
   override fun test(value: List<T>): Result {
-    val passed = value.sorted() == value
-    val snippet = if (value.size <= 10) value.joinToString(",") else value.take(10).joinToString(",") + "..."
+    val failure = value.withIndex().firstOrNull { (i, it) -> i != value.lastIndex && it > value[i+1] }
+    val snippet = if (value.size <= 10) value.joinToString(",") else value.take(10).joinToString(",", postfix =  "...")
+    val elementMessage = when (failure) {
+        null -> ""
+        else -> ". Element ${failure.value} at index ${failure.index} was greater than element ${value[failure.index+1]}"
+    }
     return Result(
-        passed,
-        "Collection $snippet should be sorted",
-        "Collection $snippet should not be sorted"
+        failure == null,
+        "List [$snippet] should be sorted$elementMessage",
+        "List [$snippet] should not be sorted"
     )
   }
 }

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/matchers/collections/CollectionMatchersTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/matchers/collections/CollectionMatchersTest.kt
@@ -84,10 +84,10 @@ class CollectionMatchersTest : WordSpec() {
         listOf(1, 2, 6, 9).shouldBeSorted()
         shouldThrow<AssertionError> {
           listOf(2, 1).shouldBeSorted()
-        }.message.shouldBe("Collection 2,1 should be sorted")
+        }.message.shouldBe("List [2,1] should be sorted. Element 2 at index 0 was greater than element 1")
         shouldThrow<AssertionError> {
           listOf(1, 2, 3).shouldNotBeSorted()
-        }.message.shouldBe("Collection 1,2,3 should not be sorted")
+        }.message.shouldBe("List [1,2,3] should not be sorted")
       }
     }
 

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/matchers/collections/CollectionMatchersTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/matchers/collections/CollectionMatchersTest.kt
@@ -1,42 +1,17 @@
 package com.sksamuel.kotlintest.matchers.collections
 
 import io.kotlintest.matchers.beEmpty
-import io.kotlintest.matchers.collections.contain
-import io.kotlintest.matchers.collections.containNoNulls
-import io.kotlintest.matchers.collections.containNull
-import io.kotlintest.matchers.collections.containOnlyNulls
-import io.kotlintest.matchers.collections.containDuplicates
-import io.kotlintest.matchers.collections.haveElementAt
-import io.kotlintest.matchers.collections.shouldBeEmpty
-import io.kotlintest.matchers.collections.shouldBeSorted
-import io.kotlintest.matchers.collections.shouldContain
-import io.kotlintest.matchers.collections.shouldContainAll
-import io.kotlintest.matchers.collections.shouldContainDuplicates
-import io.kotlintest.matchers.collections.shouldContainElementAt
-import io.kotlintest.matchers.collections.shouldContainNoNulls
-import io.kotlintest.matchers.collections.shouldContainNull
-import io.kotlintest.matchers.collections.shouldContainOnlyNulls
-import io.kotlintest.matchers.collections.shouldHaveSingleElement
-import io.kotlintest.matchers.collections.shouldHaveSize
-import io.kotlintest.matchers.collections.shouldNotBeEmpty
-import io.kotlintest.matchers.collections.shouldNotBeSorted
-import io.kotlintest.matchers.collections.shouldNotContainAll
-import io.kotlintest.matchers.collections.shouldNotContainDuplicates
-import io.kotlintest.matchers.collections.shouldNotContainElementAt
-import io.kotlintest.matchers.collections.shouldNotContainNoNulls
-import io.kotlintest.matchers.collections.shouldNotContainNull
-import io.kotlintest.matchers.collections.shouldNotContainOnlyNulls
-import io.kotlintest.matchers.collections.shouldNotHaveSize
+import io.kotlintest.matchers.collections.*
 import io.kotlintest.matchers.containAll
 import io.kotlintest.matchers.containsInOrder
 import io.kotlintest.matchers.haveSize
-import io.kotlintest.should
-import io.kotlintest.shouldNot
 import io.kotlintest.matchers.singleElement
 import io.kotlintest.matchers.sorted
-import io.kotlintest.specs.WordSpec
+import io.kotlintest.should
 import io.kotlintest.shouldBe
+import io.kotlintest.shouldNot
 import io.kotlintest.shouldThrow
+import io.kotlintest.specs.WordSpec
 import java.util.*
 
 class CollectionMatchersTest : WordSpec() {
@@ -247,6 +222,10 @@ class CollectionMatchersTest : WordSpec() {
         shouldThrow<AssertionError> {
           col should containsInOrder(2, 1, 3)
         }
+      }
+      "work with unsorted collections" {
+        val actual = listOf(5, 3, 1, 2, 4, 2)
+        actual should containsInOrder(3, 2, 2)
       }
     }
 


### PR DESCRIPTION
Instead of sorting the list and comparing every value, we can iterate
through the list once and stop when we find an element that's larger
than the following element. This also allows us to add the out-of-order
element and its index to the error message.

A similar optimization was added to the `containsInOrder` matcher, with the additional benefit that it will now work on unsorted collections.