### PR TITLE
Add matchers containsExactly and containsExactlyInAnyOrder

### DIFF
--- a/kotlintest-assertions/src/main/kotlin/io/kotlintest/matchers/collections/matchers.kt
+++ b/kotlintest-assertions/src/main/kotlin/io/kotlintest/matchers/collections/matchers.kt
@@ -8,6 +8,7 @@ import io.kotlintest.matchers.containAll
 import io.kotlintest.matchers.containsInOrder
 import io.kotlintest.matchers.haveSize
 import io.kotlintest.matchers.singleElement
+import io.kotlintest.neverNullMatcher
 import io.kotlintest.should
 import io.kotlintest.shouldNot
 
@@ -70,6 +71,36 @@ fun <T, C : Collection<T>> contain(t: T) = object : Matcher<C> {
       value.contains(t),
       "Collection should contain element $t",
       "Collection should not contain element $t"
+  )
+}
+
+fun <T, C : Collection<T>> C?.shouldNotContainExactly(expected: C) = this shouldNot containExactly(expected)
+fun <T, C : Collection<T>> C?.shouldNotContainExactly(vararg expected: T) = this shouldNot containExactly(*expected)
+fun <T, C : Collection<T>> C?.shouldContainExactly(expected: C) = this should containExactly(expected)
+fun <T, C : Collection<T>> C?.shouldContainExactly(vararg expected: T) = this should containExactly(*expected)
+fun <T> containExactly(vararg expected: T): Matcher<Collection<T>?> = containExactly(expected.asList())
+/** Assert that a collection contains exactly the given values and nothing else, in order. */
+fun <T, C : Collection<T>> containExactly(expected: C): Matcher<C?> = neverNullMatcher { value ->
+  val passed = value.size == expected.size && value.zip(expected) { a, b -> a == b }.all { it }
+  Result(
+      passed,
+      "Collection should be exactly $expected but was $value",
+      "Collection should not be exactly $expected"
+  )
+}
+
+fun <T, C : Collection<T>> C?.shouldNotContainExactlyInAnyOrder(expected: C) = this shouldNot containExactlyInAnyOrder(expected)
+fun <T, C : Collection<T>> C?.shouldNotContainExactlyInAnyOrder(vararg expected: T) = this shouldNot containExactlyInAnyOrder(*expected)
+fun <T, C : Collection<T>> C?.shouldContainExactlyInAnyOrder(expected: C) = this should containExactlyInAnyOrder(expected)
+fun <T, C : Collection<T>> C?.shouldContainExactlyInAnyOrder(vararg expected: T) = this should containExactlyInAnyOrder(*expected)
+fun <T> containExactlyInAnyOrder(vararg expected: T): Matcher<Collection<T>?> = containExactlyInAnyOrder(expected.asList())
+/** Assert that a collection contains exactly the given values and nothing else, in any order. */
+fun <T, C : Collection<T>> containExactlyInAnyOrder(expected: C): Matcher<C?> = neverNullMatcher { value ->
+  val passed = value.size == expected.size && expected.all { value.contains(it) }
+  Result(
+      passed,
+      "Collection should contain $expected in any order, but was $value",
+      "Collection should not contain exactly $expected in any order"
   )
 }
 

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/matchers/collections/CollectionMatchersTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/matchers/collections/CollectionMatchersTest.kt
@@ -1,42 +1,17 @@
 package com.sksamuel.kotlintest.matchers.collections
 
 import io.kotlintest.matchers.beEmpty
-import io.kotlintest.matchers.collections.contain
-import io.kotlintest.matchers.collections.containNoNulls
-import io.kotlintest.matchers.collections.containNull
-import io.kotlintest.matchers.collections.containOnlyNulls
-import io.kotlintest.matchers.collections.containDuplicates
-import io.kotlintest.matchers.collections.haveElementAt
-import io.kotlintest.matchers.collections.shouldBeEmpty
-import io.kotlintest.matchers.collections.shouldBeSorted
-import io.kotlintest.matchers.collections.shouldContain
-import io.kotlintest.matchers.collections.shouldContainAll
-import io.kotlintest.matchers.collections.shouldContainDuplicates
-import io.kotlintest.matchers.collections.shouldContainElementAt
-import io.kotlintest.matchers.collections.shouldContainNoNulls
-import io.kotlintest.matchers.collections.shouldContainNull
-import io.kotlintest.matchers.collections.shouldContainOnlyNulls
-import io.kotlintest.matchers.collections.shouldHaveSingleElement
-import io.kotlintest.matchers.collections.shouldHaveSize
-import io.kotlintest.matchers.collections.shouldNotBeEmpty
-import io.kotlintest.matchers.collections.shouldNotBeSorted
-import io.kotlintest.matchers.collections.shouldNotContainAll
-import io.kotlintest.matchers.collections.shouldNotContainDuplicates
-import io.kotlintest.matchers.collections.shouldNotContainElementAt
-import io.kotlintest.matchers.collections.shouldNotContainNoNulls
-import io.kotlintest.matchers.collections.shouldNotContainNull
-import io.kotlintest.matchers.collections.shouldNotContainOnlyNulls
-import io.kotlintest.matchers.collections.shouldNotHaveSize
+import io.kotlintest.matchers.collections.*
 import io.kotlintest.matchers.containAll
 import io.kotlintest.matchers.containsInOrder
 import io.kotlintest.matchers.haveSize
-import io.kotlintest.should
-import io.kotlintest.shouldNot
 import io.kotlintest.matchers.singleElement
 import io.kotlintest.matchers.sorted
-import io.kotlintest.specs.WordSpec
+import io.kotlintest.should
 import io.kotlintest.shouldBe
+import io.kotlintest.shouldNot
 import io.kotlintest.shouldThrow
+import io.kotlintest.specs.WordSpec
 import java.util.*
 
 class CollectionMatchersTest : WordSpec() {
@@ -165,6 +140,48 @@ class CollectionMatchersTest : WordSpec() {
         )
         tests should contain(TestSealed.Test1("test1"))
         tests.shouldContain(TestSealed.Test2(2))
+      }
+    }
+
+    "containExactly" should {
+      "test that a collection contains given elements exactly"  {
+        val actual = listOf(1, 2, 3)
+        emptyList<Int>() should containExactly()
+        actual should containExactly(1, 2, 3)
+        actual.shouldContainExactly(1, 2, 3)
+        actual.shouldContainExactly(linkedSetOf(1, 2, 3))
+
+        actual shouldNot containExactly(1, 2)
+        actual.shouldNotContainExactly(3, 2, 1)
+        actual.shouldNotContainExactly(listOf(5, 6, 7))
+        shouldThrow<AssertionError> {
+          actual should containExactly(1, 2)
+        }
+        shouldThrow<AssertionError> {
+          actual should containExactly(1, 2, 3, 4)
+        }
+        shouldThrow<AssertionError> {
+          actual.shouldContainExactly(3, 2, 1)
+        }
+      }
+    }
+
+    "containExactlyInAnyOrder" should {
+      "test that a collection contains given elements in any order"  {
+        val actual = listOf(1, 2, 3)
+        actual should containExactlyInAnyOrder(1, 2, 3)
+        actual.shouldContainExactlyInAnyOrder(3, 2, 1)
+        actual.shouldContainExactlyInAnyOrder(linkedSetOf(2, 1, 3))
+
+        actual shouldNot containExactlyInAnyOrder(1, 2)
+        actual.shouldNotContainExactlyInAnyOrder(1, 2, 3, 4)
+        actual.shouldNotContainExactlyInAnyOrder(listOf(5, 6, 7))
+        shouldThrow<AssertionError> {
+          actual should containExactlyInAnyOrder(1, 2)
+        }
+        shouldThrow<AssertionError> {
+          actual should containExactlyInAnyOrder(1, 2, 3, 4)
+        }
       }
     }
 


### PR DESCRIPTION
These are equivalent to the similarly named matchers in assertj.