### PR TITLE
Use less ambiguous string representations in equality errors

### DIFF
--- a/kotlintest-assertions/src/main/kotlin/io/kotlintest/dsl.kt
+++ b/kotlintest-assertions/src/main/kotlin/io/kotlintest/dsl.kt
@@ -1,9 +1,6 @@
 package io.kotlintest
 
 import io.kotlintest.matchers.ToleranceMatcher
-import java.util.concurrent.atomic.AtomicBoolean
-import java.util.concurrent.atomic.AtomicInteger
-import java.util.concurrent.atomic.AtomicLong
 
 fun <T> be(expected: T) = equalityMatcher(expected)
 fun <T> equalityMatcher(expected: T) = object : Matcher<T> {

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/InspectingTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/InspectingTest.kt
@@ -47,11 +47,11 @@ class InspectingTest : WordSpec() {
             name shouldBe "Samantha Rose"
             age shouldBe 19
             inspecting(friends.first()) {
-              name shouldBe "<Some name that is wrong>"
+              name shouldBe "Some name that is wrong"
               age shouldBe 19
             }
           }
-        }.message shouldBe "expected: <<Some name that is wrong>> but was: <John Doe>"
+        }.message shouldBe "expected: \"Some name that is wrong\" but was: \"John Doe\""
       }
     }
   }

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/matchers/MatchersTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/matchers/MatchersTest.kt
@@ -11,6 +11,7 @@ import io.kotlintest.shouldNot
 import io.kotlintest.shouldNotBe
 import io.kotlintest.shouldThrow
 import java.util.*
+import kotlin.collections.HashMap
 
 class MatchersTest : FreeSpec({
 
@@ -54,6 +55,49 @@ class MatchersTest : FreeSpec({
         name shouldBe null
       }
     }
+
+    "formats value representations" {
+      shouldThrow<AssertionError> {
+        1f shouldBe 2f
+      }.message shouldBe "expected: 2.0f but was: 1.0f"
+      shouldThrow<AssertionError> {
+        1L shouldBe 2L
+      }.message shouldBe "expected: 2L but was: 1L"
+      shouldThrow<AssertionError> {
+        'a' shouldBe 'b'
+      }.message shouldBe "expected: 'b' but was: 'a'"
+      shouldThrow<AssertionError> {
+        "a" shouldBe "b"
+      }.message shouldBe "expected: \"b\" but was: \"a\""
+      shouldThrow<AssertionError> {
+        arrayOf("a") shouldBe arrayOf("b")
+      }.message shouldBe "expected: [\"b\"] but was: [\"a\"]"
+      shouldThrow<AssertionError> {
+        floatArrayOf(1f) shouldBe floatArrayOf(2f)
+      }.message shouldBe "expected: [2.0f] but was: [1.0f]"
+      shouldThrow<AssertionError> {
+        longArrayOf(1L) shouldBe longArrayOf(2L)
+      }.message shouldBe "expected: [2L] but was: [1L]"
+      shouldThrow<AssertionError> {
+        charArrayOf('a') shouldBe charArrayOf('b')
+      }.message shouldBe "expected: ['b'] but was: ['a']"
+      shouldThrow<AssertionError> {
+        listOf('a') shouldBe listOf('b')
+      }.message shouldBe "expected: ['b'] but was: ['a']"
+      shouldThrow<AssertionError> {
+        mapOf('a' to 1L) shouldBe mapOf('b' to 2L)
+      }.message shouldBe "expected: {'b'=2L} but was: {'a'=1L}"
+      shouldThrow<AssertionError> {
+        val l = ArrayList<Any>()
+        l.add(l)
+        l shouldBe emptyList<Any>()
+      }.message shouldBe "expected: [] but was: [(this ArrayList)]"
+      shouldThrow<AssertionError> {
+        val l = HashMap<Any, Any>()
+        l[1L] = l
+        l shouldBe emptyMap<Any, Any>()
+      }.message shouldBe "expected: {} but was: {1L=(this HashMap)}"
+    }
   }
 
   "Matchers.shouldNotBe" - {
@@ -82,12 +126,6 @@ class MatchersTest : FreeSpec({
       shouldThrow<AssertionError> {
         null shouldNotBe null
       }
-    }
-  }
-
-  "Matchers.shouldEqual" - {
-    "should compare equality" {
-      "a" shouldBe "a"
     }
   }
 

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/matchers/string/StringMatchersTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/matchers/string/StringMatchersTest.kt
@@ -27,8 +27,8 @@ class StringMatchersTest : FreeSpec() {
         shouldThrow<AssertionFailedError> {
           "a" shouldBe "b"
         }.let {
-          it.actual.value shouldBe "a"
-          it.expected.value shouldBe "b"
+          it.actual.value shouldBe "\"a\""
+          it.expected.value shouldBe "\"b\""
         }
       }
     }

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/properties/shrinking/ShrinkTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/properties/shrinking/ShrinkTest.kt
@@ -46,7 +46,7 @@ class ShrinkTest : StringSpec({
       assertAll(Gen.positiveIntegers(), Gen.positiveIntegers(), Gen.positiveIntegers()) { a, b, c ->
         a.toLong() + b.toLong() + c.toLong() shouldBe 4L
       }
-    }.message shouldBe "Property failed for\nArg 0: 1 (shrunk from 2147483647)\nArg 1: 1 (shrunk from 2147483647)\nArg 2: 1 (shrunk from 2147483647)\nafter 1 attempts\nCaused by: expected: 4 but was: 6442450941"
+    }.message shouldBe "Property failed for\nArg 0: 1 (shrunk from 2147483647)\nArg 1: 1 (shrunk from 2147483647)\nArg 2: 1 (shrunk from 2147483647)\nafter 1 attempts\nCaused by: expected: 4L but was: 6442450941L"
   }
 
   "should shrink arity 4 negativeIntegers" {

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/tables/TableTestingTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/tables/TableTestingTest.kt
@@ -155,8 +155,8 @@ class TableTestingTest : StringSpec() {
         }
       }.let {
         it.message shouldNotBe null
-        it.message should contain("1) Test failed for (name, sam) with error expected: <christian> but was: <sam>")
-        it.message should contain("2) Test failed for (name, billy) with error expected: <christian> but was: <billy>")
+        it.message should contain("1) Test failed for (name, sam) with error expected: \"christian\" but was: \"sam\"")
+        it.message should contain("2) Test failed for (name, billy) with error expected: \"christian\" but was: \"billy\"")
         it.message shouldNot contain("3)")
       }
     }
@@ -175,7 +175,7 @@ class TableTestingTest : StringSpec() {
         }
       }.let {
         it.shouldNotBeInstanceOf<MultiAssertionError>()
-        it.message shouldBe "Test failed for (name, christian) with error christian should not equal christian"
+        it.message shouldBe "Test failed for (name, christian) with error \"christian\" should not equal \"christian\""
       }
     }
 
@@ -193,7 +193,7 @@ class TableTestingTest : StringSpec() {
         }
       }.let {
         it.message should contain("1) Test failed for (name, null) with error kotlin.KotlinNullPointerException")
-        it.message should contain("2) Test failed for (name, christian) with error christian should not equal christian")
+        it.message should contain("2) Test failed for (name, christian) with error \"christian\" should not equal \"christian\"")
         it.message shouldNot contain("3)")
       }
     }

--- a/kotlintest-tests/kotlintest-tests-junit4-assertions/src/test/kotlin/io/kotlintest/JUnit4AssertionsTest.kt
+++ b/kotlintest-tests/kotlintest-tests-junit4-assertions/src/test/kotlin/io/kotlintest/JUnit4AssertionsTest.kt
@@ -9,8 +9,8 @@ class JUnit4AssertionsTest {
     shouldThrow<ComparisonFailure> {
       "a" shouldBe "b"
     }.let {
-      it.actual shouldBe "a"
-      it.expected shouldBe "b"
+      it.actual shouldBe "\"a\""
+      it.expected shouldBe "\"b\""
     }
   }
 }


### PR DESCRIPTION
`toString` produces ambiguous results for a number of common types. For example:

```kotlin
"1" shouldBe 1L
```

```
expected: 1 but was: 1
```

or

```kotlin
listOf(1f) shouldBe listOf(1.0)
```

```
expected: [1.0] but was: [1.0]
```

etc.

This PR formats objects the way their literal values appear in code.

e.g.

```
expected: "1" but was: 1L
```

Now that the representations are less ambiguous, we can use the JUnit assertions for all types.