### PR TITLE
Remove matcher frames from stacktraces

### DIFF
--- a/kotlintest-assertions/src/main/kotlin/io/kotlintest/Eventually.kt
+++ b/kotlintest-assertions/src/main/kotlin/io/kotlintest/Eventually.kt
@@ -20,7 +20,7 @@ fun <T, E : Throwable> eventually(duration: Duration, exceptionClass: Class<E>, 
     }
     times++
   }
-  throw AssertionError("Test failed after ${duration.seconds} seconds; attempted $times times")
+  throw Failures.failure("Test failed after ${duration.seconds} seconds; attempted $times times")
 }
 
 fun <T> eventually(duration: Duration, predicate: (T) -> Boolean, f: () -> T): T {
@@ -34,5 +34,5 @@ fun <T> eventually(duration: Duration, predicate: (T) -> Boolean, f: () -> T): T
       times++
     }
   }
-  throw AssertionError("Test failed after ${duration.seconds} seconds; attempted $times times")
+  throw Failures.failure("Test failed after ${duration.seconds} seconds; attempted $times times")
 }

--- a/kotlintest-assertions/src/main/kotlin/io/kotlintest/ExceptionHandlers.kt
+++ b/kotlintest-assertions/src/main/kotlin/io/kotlintest/ExceptionHandlers.kt
@@ -15,12 +15,12 @@ inline fun <reified T : Throwable> shouldThrow(thunk: () -> Any?): T {
   val exceptionClass = T::class.java
   try {
     thunk()
-    throw AssertionError("Expected exception ${T::class.qualifiedName} but no exception was thrown")
+    throw Failures.failure("Expected exception ${T::class.qualifiedName} but no exception was thrown")
   } catch (e: Throwable) {
     return when {
       exceptionClass.isAssignableFrom(e.javaClass) -> e as T
       e is AssertionError -> throw e
-      else -> throw AssertionError("Expected exception ${T::class.qualifiedName} but ${e.javaClass.name} was thrown", e)
+      else -> throw Failures.failure("Expected exception ${T::class.qualifiedName} but ${e.javaClass.name} was thrown", e)
     }
   }
 }
@@ -33,7 +33,7 @@ fun shouldFail(thunk: () -> Any?) {
     false
   }
   if (passed)
-    throw AssertionError("This block should fail by throwing by exception but not exception was thrown")
+    throw Failures.failure("This block should fail by throwing by exception but not exception was thrown")
 }
 
 /**
@@ -51,12 +51,12 @@ inline fun <reified T : Throwable> shouldThrowExactly(thunk: () -> Any?): T {
   val exceptionClass = T::class.java
   try {
     thunk()
-    throw AssertionError("Expected exception ${T::class.qualifiedName} but no exception was thrown")
+    throw Failures.failure("Expected exception ${T::class.qualifiedName} but no exception was thrown")
   } catch (e: Throwable) {
     return when {
       e.javaClass == exceptionClass -> e as T
       e is AssertionError -> throw e
-      else -> throw AssertionError("Expected exception ${T::class.qualifiedName} but ${e.javaClass.name} was thrown", e)
+      else -> throw Failures.failure("Expected exception ${T::class.qualifiedName} but ${e.javaClass.name} was thrown", e)
     }
   }
 }
@@ -74,7 +74,7 @@ inline fun shouldThrowAny(thunk: () -> Any?): Throwable {
   }
 
   if (e == null)
-    throw AssertionError("Expected exception but no exception was thrown")
+    throw Failures.failure("Expected exception but no exception was thrown")
   else
     return e
 }

--- a/kotlintest-assertions/src/main/kotlin/io/kotlintest/Failures.kt
+++ b/kotlintest-assertions/src/main/kotlin/io/kotlintest/Failures.kt
@@ -1,0 +1,36 @@
+package io.kotlintest
+
+object Failures {
+  /**
+   * Whether KotlinTest-related frames will be removed from the stack traces of thrown [AssertionError]s.
+   */
+  var shouldRemoveKotlintestElementsFromStacktrace: Boolean = true
+
+  /**
+   * Creates an [AssertionError] with the given [message] and [cause]
+   *
+   * If [shouldRemoveKotlintestElementsFromStacktrace] is `true`, [removeKotlintestElementsFromStacktrace] will be
+   * called on the returned error.
+   */
+  fun failure(message: String, cause: Throwable?=null): AssertionError = AssertionError(message).apply {
+    if (shouldRemoveKotlintestElementsFromStacktrace) {
+      removeKotlintestElementsFromStacktrace(this)
+    }
+    if (cause != null) {
+      initCause(cause)
+    }
+  }
+
+  /**
+   * Remove KotlinTest-related elements from the top of [throwable]'s stack trace.
+   *
+   * If no KotlinTest-related elements are present in the stack trace, it is unchanged.
+   */
+  fun removeKotlintestElementsFromStacktrace(throwable: Throwable) {
+    val stackTrace = throwable.stackTrace
+    val lastKotlintestIndex = stackTrace.indexOfLast {
+      it.className.startsWith("io.kotlintest") && ! it.className.startsWith("io.kotlintest.runner")
+    }
+    throwable.stackTrace = stackTrace.drop(lastKotlintestIndex + 1).toTypedArray()
+  }
+}

--- a/kotlintest-assertions/src/main/kotlin/io/kotlintest/Failures.kt
+++ b/kotlintest-assertions/src/main/kotlin/io/kotlintest/Failures.kt
@@ -3,8 +3,17 @@ package io.kotlintest
 object Failures {
   /**
    * Whether KotlinTest-related frames will be removed from the stack traces of thrown [AssertionError]s.
+   *
+   * This defaults to `true`. You can change it at runtime, or set it with the system property
+   * `kotlintest.failures.stacktrace.clean`.
+   *
+   * e.g.
+   *
+   * ```
+   * -Dkotlintest.failures.stacktrace.clean=false
+   * ```
    */
-  var shouldRemoveKotlintestElementsFromStacktrace: Boolean = true
+  var shouldRemoveKotlintestElementsFromStacktrace: Boolean = readSystemProperty()
 
   /**
    * Creates an [AssertionError] with the given [message] and [cause]
@@ -32,5 +41,9 @@ object Failures {
       it.className.startsWith("io.kotlintest") && ! it.className.startsWith("io.kotlintest.runner")
     }
     throwable.stackTrace = stackTrace.drop(lastKotlintestIndex + 1).toTypedArray()
+  }
+
+  private fun readSystemProperty(): Boolean {
+    return System.getProperty("kotlintest.failures.stacktrace.clean")?.toBoolean() ?: true
   }
 }

--- a/kotlintest-assertions/src/main/kotlin/io/kotlintest/inspectors/funcs.kt
+++ b/kotlintest-assertions/src/main/kotlin/io/kotlintest/inspectors/funcs.kt
@@ -2,6 +2,7 @@ package io.kotlintest.inspectors
 
 import convertValueToString
 import exceptionToMessage
+import io.kotlintest.Failures
 
 fun <T> runTests(col: Collection<T>, f: (T) -> Unit): List<ElementResult<T>> {
   return col.map {
@@ -32,6 +33,6 @@ fun <T> buildAssertionError(msg: String, results: List<ElementResult<T>>): Strin
   } else {
     builder.append(failed.joinToString("\n") { convertValueToString(it.value) + " => " + exceptionToMessage(it.error) })
   }
-  throw AssertionError(builder.toString())
+  throw Failures.failure(builder.toString())
 }
 

--- a/kotlintest-assertions/src/main/kotlin/io/kotlintest/matchers/concurrent/concurrent.kt
+++ b/kotlintest-assertions/src/main/kotlin/io/kotlintest/matchers/concurrent/concurrent.kt
@@ -1,5 +1,6 @@
 package io.kotlintest.matchers.concurrent
 
+import io.kotlintest.Failures
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
@@ -17,7 +18,7 @@ fun <A> shouldCompleteWithin(timeout: Long, unit: TimeUnit, thunk: () -> A) {
 
   if (!latch.await(timeout, unit)) {
     t.interrupt()
-    throw AssertionError("Test should have completed within $timeout/$unit")
+    throw Failures.failure("Test should have completed within $timeout/$unit")
   }
 
   ref.get()
@@ -38,6 +39,6 @@ fun <A> shouldTimeout(timeout: Long, unit: TimeUnit, thunk: () -> A) {
   if (timedOut) {
     t.interrupt()
   } else {
-    throw AssertionError("Expected test to timeout for $timeout/$unit")
+    throw Failures.failure("Expected test to timeout for $timeout/$unit")
   }
 }

--- a/kotlintest-assertions/src/main/kotlin/io/kotlintest/matchers/matchers.kt
+++ b/kotlintest-assertions/src/main/kotlin/io/kotlintest/matchers/matchers.kt
@@ -2,6 +2,7 @@
 
 package io.kotlintest.matchers
 
+import io.kotlintest.Failures
 import io.kotlintest.Matcher
 import io.kotlintest.Result
 
@@ -9,7 +10,7 @@ fun withClue(clue: String, thunk: () -> Any) {
   try {
     thunk()
   } catch (e: AssertionError) {
-    throw AssertionError("$clue $e")
+    throw Failures.failure("$clue $e")
   }
 }
 

--- a/kotlintest-assertions/src/main/kotlin/io/kotlintest/properties/PropertyTestingAssertAll.kt
+++ b/kotlintest-assertions/src/main/kotlin/io/kotlintest/properties/PropertyTestingAssertAll.kt
@@ -202,7 +202,7 @@ fun <A, B, C, D, E, F> assertAll(iterations: Int, gena: Gen<A>, genb: Gen<B>, ge
           PropertyFailureInput<E>(e, smallestE),
           PropertyFailureInput<F>(f, smallestF)
       )
-      throw PropertyAssertionError(x, context.attempts(), inputs)
+      throw propertyAssertionError(x, context.attempts(), inputs)
     }
   }
 

--- a/kotlintest-assertions/src/main/kotlin/io/kotlintest/properties/PropertyTestingAssertNone.kt
+++ b/kotlintest-assertions/src/main/kotlin/io/kotlintest/properties/PropertyTestingAssertNone.kt
@@ -1,5 +1,6 @@
 package io.kotlintest.properties
 
+import io.kotlintest.Failures
 import outputClassifications
 
 inline fun <reified A> assertNone(noinline fn: PropertyContext.(a: A) -> Unit) = assertNone(1000, fn)
@@ -22,7 +23,7 @@ fun <A> assertNone(iterations: Int, gena: Gen<A>, fn: PropertyContext.(a: A) -> 
       throw e
     }
     if (passed)
-      throw AssertionError("Property passed for\n$a\nafter ${context.attempts()} attempts")
+      throw Failures.failure("Property passed for\n$a\nafter ${context.attempts()} attempts")
   }
   for (a in gena.constants()) {
     test(a)
@@ -58,7 +59,7 @@ fun <A, B> assertNone(iterations: Int, gena: Gen<A>, genb: Gen<B>, fn: PropertyC
       throw e
     }
     if (passed)
-      throw AssertionError("Property passed for\n$a\n$b\nafter ${context.attempts()} attempts")
+      throw Failures.failure("Property passed for\n$a\n$b\nafter ${context.attempts()} attempts")
   }
   for (a in gena.constants()) {
     for (b in genb.constants()) {
@@ -100,7 +101,7 @@ fun <A, B, C> assertNone(iterations: Int, gena: Gen<A>, genb: Gen<B>, genc: Gen<
       throw e
     }
     if (passed)
-      throw AssertionError("Property passed for\n$a\n$b\n$c\nafter ${context.attempts()} attempts")
+      throw Failures.failure("Property passed for\n$a\n$b\n$c\nafter ${context.attempts()} attempts")
   }
   for (a in gena.constants()) {
     for (b in genb.constants()) {
@@ -145,7 +146,7 @@ fun <A, B, C, D> assertNone(iterations: Int, gena: Gen<A>, genb: Gen<B>, genc: G
       throw e
     }
     if (passed)
-      throw AssertionError("Property passed for\n$a\n$b\n$c\n$d\nafter ${context.attempts()} attempts")
+      throw Failures.failure("Property passed for\n$a\n$b\n$c\n$d\nafter ${context.attempts()} attempts")
   }
   for (a in gena.constants()) {
     for (b in genb.constants()) {
@@ -190,7 +191,7 @@ fun <A, B, C, D, E> assertNone(iterations: Int, gena: Gen<A>, genb: Gen<B>, genc
       throw e
     }
     if (passed)
-      throw AssertionError("Property passed for\n$a\n$b\n$c\n$d\n$e\nafter ${context.attempts()} attempts")
+      throw Failures.failure("Property passed for\n$a\n$b\n$c\n$d\n$e\nafter ${context.attempts()} attempts")
   }
   for (a in gena.constants()) {
     for (b in genb.constants()) {
@@ -244,7 +245,7 @@ fun <A, B, C, D, E, F> assertNone(iterations: Int, gena: Gen<A>, genb: Gen<B>, g
       throw e
     }
     if (passed)
-      throw AssertionError("Property passed for\n$a\n$b\n$c\n$d\n$e\n$f\nafter ${context.attempts()} attempts")
+      throw Failures.failure("Property passed for\n$a\n$b\n$c\n$d\n$e\n$f\nafter ${context.attempts()} attempts")
   }
 
   for (a in gena.constants()) {

--- a/kotlintest-assertions/src/main/kotlin/io/kotlintest/properties/PropertyTestingForNone.kt
+++ b/kotlintest-assertions/src/main/kotlin/io/kotlintest/properties/PropertyTestingForNone.kt
@@ -1,5 +1,6 @@
 package io.kotlintest.properties
 
+import io.kotlintest.Failures
 import outputClassifications
 
 inline fun <reified A> forNone(noinline fn: PropertyContext.(a: A) -> Boolean) = forNone(1000, fn)
@@ -15,7 +16,7 @@ fun <A> forNone(iterations: Int, gena: Gen<A>, fn: PropertyContext.(a: A) -> Boo
     context.inc()
     val passed = context.fn(a)
     if (passed) {
-      throw AssertionError("Property passed for\n$a\nafter ${context.attempts()} attempts")
+      throw Failures.failure("Property passed for\n$a\nafter ${context.attempts()} attempts")
     }
   }
   for (a in gena.constants()) {
@@ -45,7 +46,7 @@ fun <A, B> forNone(iterations: Int, gena: Gen<A>, genb: Gen<B>, fn: PropertyCont
     context.inc()
     val passed = context.fn(a, b)
     if (passed) {
-      throw AssertionError("Property passed for\n$a\n$b\nafter ${context.attempts()} attempts")
+      throw Failures.failure("Property passed for\n$a\n$b\nafter ${context.attempts()} attempts")
     }
   }
   for (a in gena.constants()) {
@@ -83,7 +84,7 @@ fun <A, B, C> forNone(iterations: Int, gena: Gen<A>, genb: Gen<B>, genc: Gen<C>,
         context.inc()
         val passed = context.fn(a, b, c)
         if (passed) {
-          throw AssertionError("Property passed for\n$a\n$b\n$c\nafter ${context.attempts()} attempts")
+          throw Failures.failure("Property passed for\n$a\n$b\n$c\nafter ${context.attempts()} attempts")
         }
       }
     }
@@ -98,7 +99,7 @@ fun <A, B, C> forNone(iterations: Int, gena: Gen<A>, genb: Gen<B>, genc: Gen<C>,
     context.inc()
     val passed = context.fn(a, b, c)
     if (passed) {
-      throw AssertionError("Property passed for\n$a\n$b\n$c\nafter ${context.attempts()} attempts")
+      throw Failures.failure("Property passed for\n$a\n$b\n$c\nafter ${context.attempts()} attempts")
     }
   }
   outputClassifications(context)
@@ -121,7 +122,7 @@ fun <A, B, C, D> forNone(iterations: Int, gena: Gen<A>, genb: Gen<B>, genc: Gen<
     context.inc()
     val passed = context.fn(a, b, c, d)
     if (passed) {
-      throw AssertionError("Property passed for\n$a\n$b\n$c\n$d\nafter ${context.attempts()} attempts")
+      throw Failures.failure("Property passed for\n$a\n$b\n$c\n$d\nafter ${context.attempts()} attempts")
     }
   }
   for (a in gena.constants()) {
@@ -160,7 +161,7 @@ fun <A, B, C, D, E> forNone(iterations: Int, gena: Gen<A>, genb: Gen<B>, genc: G
     context.inc()
     val passed = context.fn(a, b, c, d, e)
     if (passed) {
-      throw AssertionError("Property passed for\n$a\n$b\n$c\n$d\n$e\nafter ${context.attempts()} attempts")
+      throw Failures.failure("Property passed for\n$a\n$b\n$c\n$d\n$e\nafter ${context.attempts()} attempts")
     }
   }
   for (a in gena.constants()) {
@@ -210,7 +211,7 @@ fun <A, B, C, D, E, F> forNone(iterations: Int, gena: Gen<A>, genb: Gen<B>, genc
     context.inc()
     val passed = context.fn(a, b, c, d, e, f)
     if (passed) {
-      throw AssertionError("Property passed for\n$a\n$b\n$c\n$d\n$e\n$f\nafter ${context.attempts()} attempts")
+      throw Failures.failure("Property passed for\n$a\n$b\n$c\n$d\n$e\n$f\nafter ${context.attempts()} attempts")
     }
   }
 

--- a/kotlintest-assertions/src/main/kotlin/io/kotlintest/properties/PropertyTestingVerifyNone.kt
+++ b/kotlintest-assertions/src/main/kotlin/io/kotlintest/properties/PropertyTestingVerifyNone.kt
@@ -1,5 +1,6 @@
 package io.kotlintest.properties
 
+import io.kotlintest.Failures
 import outputClassifications
 
 inline fun <reified A> verifyNone(noinline fn: PropertyContext.(a: A) -> Boolean) = verifyNone(1000, fn)
@@ -15,7 +16,7 @@ fun <A> verifyNone(iterations: Int, gena: Gen<A>, fn: PropertyContext.(a: A) -> 
     context.inc()
     val passed = context.fn(a)
     if (passed) {
-      throw AssertionError("Property passed for\n$a\nafter ${context.attempts()} attempts")
+      throw Failures.failure("Property passed for\n$a\nafter ${context.attempts()} attempts")
     }
   }
   for (a in gena.constants()) {
@@ -45,7 +46,7 @@ fun <A, B> verifyNone(iterations: Int, gena: Gen<A>, genb: Gen<B>, fn: PropertyC
     context.inc()
     val passed = context.fn(a, b)
     if (passed) {
-      throw AssertionError("Property passed for\n$a\n$b\nafter ${context.attempts()} attempts")
+      throw Failures.failure("Property passed for\n$a\n$b\nafter ${context.attempts()} attempts")
     }
   }
   for (a in gena.constants()) {
@@ -83,7 +84,7 @@ fun <A, B, C> verifyNone(iterations: Int, gena: Gen<A>, genb: Gen<B>, genc: Gen<
         context.inc()
         val passed = context.fn(a, b, c)
         if (passed) {
-          throw AssertionError("Property passed for\n$a\n$b\n$c\nafter ${context.attempts()} attempts")
+          throw Failures.failure("Property passed for\n$a\n$b\n$c\nafter ${context.attempts()} attempts")
         }
       }
     }
@@ -98,7 +99,7 @@ fun <A, B, C> verifyNone(iterations: Int, gena: Gen<A>, genb: Gen<B>, genc: Gen<
     context.inc()
     val passed = context.fn(a, b, c)
     if (passed) {
-      throw AssertionError("Property passed for\n$a\n$b\n$c\nafter ${context.attempts()} attempts")
+      throw Failures.failure("Property passed for\n$a\n$b\n$c\nafter ${context.attempts()} attempts")
     }
   }
   outputClassifications(context)
@@ -121,7 +122,7 @@ fun <A, B, C, D> verifyNone(iterations: Int, gena: Gen<A>, genb: Gen<B>, genc: G
     context.inc()
     val passed = context.fn(a, b, c, d)
     if (passed) {
-      throw AssertionError("Property passed for\n$a\n$b\n$c\n$d\nafter ${context.attempts()} attempts")
+      throw Failures.failure("Property passed for\n$a\n$b\n$c\n$d\nafter ${context.attempts()} attempts")
     }
   }
   for (a in gena.constants()) {
@@ -160,7 +161,7 @@ fun <A, B, C, D, E> verifyNone(iterations: Int, gena: Gen<A>, genb: Gen<B>, genc
     context.inc()
     val passed = context.fn(a, b, c, d, e)
     if (passed) {
-      throw AssertionError("Property passed for\n$a\n$b\n$c\n$d\n$e\nafter ${context.attempts()} attempts")
+      throw Failures.failure("Property passed for\n$a\n$b\n$c\n$d\n$e\nafter ${context.attempts()} attempts")
     }
   }
   for (a in gena.constants()) {
@@ -210,7 +211,7 @@ fun <A, B, C, D, E, F> verifyNone(iterations: Int, gena: Gen<A>, genb: Gen<B>, g
     context.inc()
     val passed = context.fn(a, b, c, d, e, f)
     if (passed) {
-      throw AssertionError("Property passed for\n$a\n$b\n$c\n$d\n$e\n$f\nafter ${context.attempts()} attempts")
+      throw Failures.failure("Property passed for\n$a\n$b\n$c\n$d\n$e\n$f\nafter ${context.attempts()} attempts")
     }
   }
 

--- a/kotlintest-assertions/src/main/kotlin/io/kotlintest/properties/errors.kt
+++ b/kotlintest-assertions/src/main/kotlin/io/kotlintest/properties/errors.kt
@@ -1,6 +1,7 @@
 package io.kotlintest.properties
 
 import convertValueToString
+import io.kotlintest.Failures
 
 fun propertyTestFailureMessage(attempt: Int,
                                inputs: List<PropertyFailureInput<out Any?>>,
@@ -24,6 +25,8 @@ fun propertyTestFailureMessage(attempt: Int,
 
 data class PropertyFailureInput<T>(val original: T?, val shrunk: T?)
 
-class PropertyAssertionError(val e: AssertionError,
-                             val attempt: Int,
-                             val inputs: List<PropertyFailureInput<out Any?>>) : AssertionError(propertyTestFailureMessage(attempt, inputs, e), e)
+internal fun propertyAssertionError(e: AssertionError,
+                                    attempt: Int,
+                                    inputs: List<PropertyFailureInput<out Any?>>): AssertionError {
+  return Failures.failure(propertyTestFailureMessage(attempt, inputs, e), e)
+}

--- a/kotlintest-assertions/src/main/kotlin/io/kotlintest/properties/shrinking/shrink.kt
+++ b/kotlintest-assertions/src/main/kotlin/io/kotlintest/properties/shrinking/shrink.kt
@@ -1,5 +1,5 @@
 import io.kotlintest.properties.Gen
-import io.kotlintest.properties.PropertyAssertionError
+import io.kotlintest.properties.propertyAssertionError
 import io.kotlintest.properties.PropertyContext
 import io.kotlintest.properties.PropertyFailureInput
 import io.kotlintest.properties.shrinking.Shrinker
@@ -72,5 +72,5 @@ fun <A, B, C, D> shrinkInputs(a: A,
       PropertyFailureInput<C>(c, smallestC),
       PropertyFailureInput<D>(d, smallestD)
   )
-  throw PropertyAssertionError(e, context.attempts(), inputs)
+  throw propertyAssertionError(e, context.attempts(), inputs)
 }

--- a/kotlintest-assertions/src/main/kotlin/io/kotlintest/properties/tests.kt
+++ b/kotlintest-assertions/src/main/kotlin/io/kotlintest/properties/tests.kt
@@ -1,5 +1,5 @@
 import io.kotlintest.properties.Gen
-import io.kotlintest.properties.PropertyAssertionError
+import io.kotlintest.properties.propertyAssertionError
 import io.kotlintest.properties.PropertyContext
 import io.kotlintest.properties.PropertyFailureInput
 import io.kotlintest.properties.shrinking.Shrinker
@@ -11,7 +11,7 @@ fun <A> testAndShrink(a: A, shrinkera: Shrinker<A>?, context: PropertyContext, f
   } catch (e: AssertionError) {
     val smallestA = shrink2(a, shrinkera, { context.fn(it) })
     val inputs = listOf(PropertyFailureInput<A>(a, smallestA))
-    throw PropertyAssertionError(e, context.attempts(), inputs)
+    throw propertyAssertionError(e, context.attempts(), inputs)
   }
 }
 
@@ -26,7 +26,7 @@ fun <A, B> testAndShrink(a: A, b: B, shrinkera: Shrinker<A>?, shrinkerb: Shrinke
         PropertyFailureInput<A>(a, smallestA),
         PropertyFailureInput<B>(b, smallestB)
     )
-    throw PropertyAssertionError(e, context.attempts(), inputs)
+    throw propertyAssertionError(e, context.attempts(), inputs)
   }
 }
 
@@ -43,7 +43,7 @@ fun <A, B, C> testAndShrink(a: A, b: B, c: C, gena: Gen<A>, genb: Gen<B>, genc: 
         PropertyFailureInput<B>(b, smallestB),
         PropertyFailureInput<C>(c, smallestC)
     )
-    throw PropertyAssertionError(e, context.attempts(), inputs)
+    throw propertyAssertionError(e, context.attempts(), inputs)
   }
 }
 
@@ -73,6 +73,6 @@ fun <A, B, C, D, E> testAndShrink(a: A, b: B, c: C, d: D, e: E, gena: Gen<A>, ge
         PropertyFailureInput<D>(d, smallestD),
         PropertyFailureInput<E>(e, smallestE)
     )
-    throw PropertyAssertionError(ex, context.attempts(), inputs)
+    throw propertyAssertionError(ex, context.attempts(), inputs)
   }
 }

--- a/kotlintest-assertions/src/main/kotlin/io/kotlintest/tables/TableTesting.kt
+++ b/kotlintest-assertions/src/main/kotlin/io/kotlintest/tables/TableTesting.kt
@@ -1,5 +1,7 @@
 package io.kotlintest.tables
 
+import io.kotlintest.Failures
+
 fun headers(a: String) = Headers1(a)
 fun headers(a: String, b: String) = Headers2(a, b)
 fun headers(a: String, b: String, c: String) = Headers3(a, b, c)
@@ -80,12 +82,12 @@ private fun error(e: Throwable, headers: List<String>, values: List<*>): Asserti
     else -> e.toString()
   }
 
-  return AssertionError("Test failed for $params with error $message", e)
+  return Failures.failure("Test failed for $params with error $message")
 }
 
 private fun error(headers: List<String>, values: List<*>): AssertionError {
   val params = headers.zip(values).joinToString(", ")
-  return AssertionError("Test passed for $params but expected failure")
+  return Failures.failure("Test passed for $params but expected failure")
 }
 
 private class ErrorCollector {

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/FailuresTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/FailuresTest.kt
@@ -1,0 +1,25 @@
+package com.sksamuel.kotlintest
+
+import io.kotlintest.Failures
+import io.kotlintest.matchers.string.shouldContain
+import io.kotlintest.matchers.string.shouldStartWith
+import io.kotlintest.shouldBe
+import io.kotlintest.shouldThrowAny
+import io.kotlintest.specs.FreeSpec
+
+class FailuresTest : FreeSpec({
+
+  "Failures.failure" - {
+
+    "filters stacktrace" {
+      val failure = Failures.failure("msg")
+      failure.message shouldBe "msg"
+      failure.stackTrace[0].className.shouldStartWith("com.sksamuel.kotlintest.FailuresTest")
+    }
+
+    "filters stacktrace when called by shouldBe" {
+      shouldThrowAny { 1 shouldBe 2 }
+          .stackTrace[0].className.shouldStartWith("com.sksamuel.kotlintest.FailuresTest")
+    }
+  }
+})

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/FailuresTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/FailuresTest.kt
@@ -12,8 +12,10 @@ class FailuresTest : FreeSpec({
   "Failures.failure" - {
 
     "filters stacktrace" {
-      val failure = Failures.failure("msg")
+      val cause = RuntimeException()
+      val failure = Failures.failure("msg", cause)
       failure.message shouldBe "msg"
+      failure.cause shouldBe cause
       failure.stackTrace[0].className.shouldStartWith("com.sksamuel.kotlintest.FailuresTest")
     }
 

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/properties/ExtensionAssertAllTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/properties/ExtensionAssertAllTest.kt
@@ -3,7 +3,6 @@ package com.sksamuel.kotlintest.properties
 import io.kotlintest.matchers.lt
 import io.kotlintest.matchers.string.shouldHaveLength
 import io.kotlintest.matchers.string.shouldHaveSameLengthAs
-import io.kotlintest.properties.PropertyAssertionError
 import io.kotlintest.properties.assertAll
 import io.kotlintest.shouldBe
 import io.kotlintest.shouldThrow
@@ -21,7 +20,7 @@ class ExtensionAssertAllTest : StringSpec({
   }
 
   "KFunction1 should report errors" {
-    shouldThrow<PropertyAssertionError> {
+    shouldThrow<AssertionError> {
       ::reverse.assertAll { input, _ ->
         input.shouldHaveSameLengthAs("qwqew")
       }
@@ -37,7 +36,7 @@ class ExtensionAssertAllTest : StringSpec({
     }
   }
   "KFunction2 should report errors" {
-    shouldThrow<PropertyAssertionError> {
+    shouldThrow<AssertionError> {
       ::concat.assertAll { _, _, output ->
         output.length shouldBe lt(5)
       }

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/tables/TableTestingTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/tables/TableTestingTest.kt
@@ -154,10 +154,11 @@ class TableTestingTest : StringSpec() {
           it shouldBe "christian"
         }
       }.let {
+        println(it.message)
         it.message shouldNotBe null
         it.message should contain("1) Test failed for (name, sam) with error expected: \"christian\" but was: \"sam\"")
         it.message should contain("2) Test failed for (name, billy) with error expected: \"christian\" but was: \"billy\"")
-        it.message shouldNot contain("3)")
+        it.message shouldNot contain("3) Test failed")
       }
     }
 
@@ -194,7 +195,7 @@ class TableTestingTest : StringSpec() {
       }.let {
         it.message should contain("1) Test failed for (name, null) with error kotlin.KotlinNullPointerException")
         it.message should contain("2) Test failed for (name, christian) with error \"christian\" should not equal \"christian\"")
-        it.message shouldNot contain("3)")
+        it.message shouldNot contain("3) Test failed")
       }
     }
   }


### PR DESCRIPTION
Currently when an assertion fails, the error's stack trace starts witha number of frames of internal kotlintest functions. #366 makes this even worse by adding several frames of reflection calls.

User's just want to see the line in their test that caused the failure, so this PR removes kotlintest frames off of the top of the stack in the `AssertionErrors` that it creates. This puts the user's code at the top of the stack. It does not remove frames associated with the kotlintest runner, since these occur below user code.

Current behavior:

```
org.opentest4j.AssertionFailedError: expected: true but was: false
    at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
    at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
    at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
    at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
    at io.kotlintest.DslKt.callPublicConstructor(dsl.kt:184)
    at io.kotlintest.DslKt.junit5assertionFailedError(dsl.kt:161)
    at io.kotlintest.DslKt.equalsError(dsl.kt:148)
    at io.kotlintest.DslKt.shouldBe(dsl.kt:49)
    at com.example.MyTest.myTest(MyTest.kt:21)
    at io.kotlintest.runner.jvm.TestCaseExecutor$executeTestSet$1.run(TestCaseExecutor.kt:96)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
    at java.lang.Thread.run(Thread.java:748)
```

Behavior with this PR:

```
org.opentest4j.AssertionFailedError: expected: true but was: false
    at com.example.MyTest.myTest(MyTest.kt:21)
    at io.kotlintest.runner.jvm.TestCaseExecutor$executeTestSet$1.run(TestCaseExecutor.kt:96)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
    at java.lang.Thread.run(Thread.java:748)
```
Users can turn this behavior off and see the full stack trace by setting `Failures.shouldRemoveKotlintestElementsFromStacktrace = false`.