### PR TITLE
Fix error when running single test in kotlintest-tests

### DIFF
--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/AutoCloseTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/AutoCloseTest.kt
@@ -15,7 +15,8 @@ class AutoCloseTest : StringSpec() {
 
   init {
     "should close resources in reverse order" {
-      // nothing to do here
+      resourceA.closed = false
+      resourceB.closed = false
     }
   }
 }
@@ -29,7 +30,7 @@ object AutoCloseListener : TestListener {
 
 object Closeable1 : Closeable {
 
-  var closed = false
+  var closed = true
 
   override fun close() {
     closed = true
@@ -38,7 +39,7 @@ object Closeable1 : Closeable {
 
 object Closeable2 : Closeable {
 
-  var closed = false
+  var closed = true
 
   override fun close() {
     assert(Closeable1.closed)


### PR DESCRIPTION
Currently, `AutoCloseListener` is registered project wide, but closables it checks are only closed when `AutoCloseTest` is run. This is fine if you run the entire test suite, but when running an individual test, it causes the listener's assertions to fail.

This PR changes `AutoCloseTest` so that the closables are considered closed unless that test has actually run.