### PR TITLE
Fix table testing forNone and Double between matcher

### DIFF
--- a/kotlintest-assertions/src/main/kotlin/io/kotlintest/matchers/DoubleMatchers.kt
+++ b/kotlintest-assertions/src/main/kotlin/io/kotlintest/matchers/DoubleMatchers.kt
@@ -2,6 +2,7 @@ package io.kotlintest.matchers
 
 import io.kotlintest.Matcher
 import io.kotlintest.Result
+import kotlin.math.abs
 
 infix fun Double.plusOrMinus(tolerance: Double): ToleranceMatcher = ToleranceMatcher(this, tolerance)
 
@@ -14,11 +15,11 @@ fun between(a: Double, b: Double, tolerance: Double): Matcher<Double> = object :
     val differenceToMinimum = value - a
     val differenceToMaximum = b - value
 
-    if (differenceToMinimum < 0 && differenceToMinimum > tolerance) {
+    if (differenceToMinimum < 0 && abs(differenceToMinimum) > tolerance) {
       return Result(false, "$value should be bigger than $a", "$value should not be bigger than $a")
     }
 
-    if (differenceToMaximum < 0 && differenceToMaximum > tolerance) {
+    if (differenceToMaximum < 0 && abs(differenceToMaximum) > tolerance) {
       return Result(false, "$value should be smaller than $b", "$value should not be smaller than $b")
     }
 

--- a/kotlintest-assertions/src/main/kotlin/io/kotlintest/tables/TableTesting.kt
+++ b/kotlintest-assertions/src/main/kotlin/io/kotlintest/tables/TableTesting.kt
@@ -85,7 +85,7 @@ private fun error(e: Throwable, headers: List<String>, values: List<*>): Asserti
   return Failures.failure("Test failed for $params with error $message")
 }
 
-private fun error(headers: List<String>, values: List<*>): AssertionError {
+private fun forNoneError(headers: List<String>, values: List<*>): AssertionError {
   val params = headers.zip(values).joinToString(", ")
   return Failures.failure("Test passed for $params but expected failure")
 }
@@ -398,9 +398,10 @@ fun <A> forNone(table: Table1<A>, fn: (A) -> Unit) {
   for (row in table.rows) {
     try {
       fn(row.a)
-      throw error(table.headers.values(), row.values())
     } catch (e: AssertionError) {
+      continue
     }
+    throw forNoneError(table.headers.values(), row.values())
   }
 }
 
@@ -408,9 +409,10 @@ fun <A, B> forNone(table: Table2<A, B>, fn: (A, B) -> Unit) {
   for (row in table.rows) {
     try {
       fn(row.a, row.b)
-      throw error(table.headers.values(), row.values())
     } catch (e: AssertionError) {
+      continue
     }
+    throw forNoneError(table.headers.values(), row.values())
   }
 }
 
@@ -418,9 +420,10 @@ fun <A, B, C> forNone(table: Table3<A, B, C>, fn: (A, B, C) -> Unit) {
   for (row in table.rows) {
     try {
       fn(row.a, row.b, row.c)
-      throw error(table.headers.values(), row.values())
     } catch (e: AssertionError) {
+      continue
     }
+    throw forNoneError(table.headers.values(), row.values())
   }
 }
 
@@ -428,9 +431,10 @@ fun <A, B, C, D> forNone(table: Table4<A, B, C, D>, fn: (A, B, C, D) -> Unit) {
   for (row in table.rows) {
     try {
       fn(row.a, row.b, row.c, row.d)
-      throw error(table.headers.values(), row.values())
     } catch (e: AssertionError) {
+      continue
     }
+    throw forNoneError(table.headers.values(), row.values())
   }
 }
 
@@ -438,9 +442,10 @@ fun <A, B, C, D, E> forNone(table: Table5<A, B, C, D, E>, fn: (A, B, C, D, E) ->
   for (row in table.rows) {
     try {
       fn(row.a, row.b, row.c, row.d, row.e)
-      throw error(table.headers.values(), row.values())
     } catch (e: AssertionError) {
+      continue
     }
+    throw forNoneError(table.headers.values(), row.values())
   }
 }
 
@@ -449,9 +454,10 @@ fun <A, B, C, D, E, F> forNone(table: Table6<A, B, C, D, E, F>, fn: (A, B, C, D,
   for (row in table.rows) {
     try {
       fn(row.a, row.b, row.c, row.d, row.e, row.f)
-      throw error(table.headers.values(), row.values())
     } catch (e: AssertionError) {
+      continue
     }
+    throw forNoneError(table.headers.values(), row.values())
   }
 }
 
@@ -459,9 +465,10 @@ fun <A, B, C, D, E, F, G> forNone(table: Table7<A, B, C, D, E, F, G>, fn: (A, B,
   for (row in table.rows) {
     try {
       fn(row.a, row.b, row.c, row.d, row.e, row.f, row.g)
-      throw error(table.headers.values(), row.values())
     } catch (e: AssertionError) {
+      continue
     }
+    throw forNoneError(table.headers.values(), row.values())
   }
 }
 
@@ -469,9 +476,10 @@ fun <A, B, C, D, E, F, G, H> forNone(table: Table8<A, B, C, D, E, F, G, H>, fn: 
   for (row in table.rows) {
     try {
       fn(row.a, row.b, row.c, row.d, row.e, row.f, row.g, row.h)
-      throw error(table.headers.values(), row.values())
     } catch (e: AssertionError) {
+      continue
     }
+    throw forNoneError(table.headers.values(), row.values())
   }
 }
 
@@ -479,9 +487,10 @@ fun <A, B, C, D, E, F, G, H, I> forNone(table: Table9<A, B, C, D, E, F, G, H, I>
   for (row in table.rows) {
     try {
       fn(row.a, row.b, row.c, row.d, row.e, row.f, row.g, row.h, row.i)
-      throw error(table.headers.values(), row.values())
     } catch (e: AssertionError) {
+      continue
     }
+    throw forNoneError(table.headers.values(), row.values())
   }
 }
 
@@ -489,9 +498,10 @@ fun <A, B, C, D, E, F, G, H, I, J> forNone(table: Table10<A, B, C, D, E, F, G, H
   for (row in table.rows) {
     try {
       fn(row.a, row.b, row.c, row.d, row.e, row.f, row.g, row.h, row.i, row.j)
-      throw error(table.headers.values(), row.values())
     } catch (e: AssertionError) {
+      continue
     }
+    throw forNoneError(table.headers.values(), row.values())
   }
 }
 
@@ -499,9 +509,10 @@ fun <A, B, C, D, E, F, G, H, I, J, K> forNone(table: Table11<A, B, C, D, E, F, G
   for (row in table.rows) {
     try {
       fn(row.a, row.b, row.c, row.d, row.e, row.f, row.g, row.h, row.i, row.j, row.k)
-      throw error(table.headers.values(), row.values())
     } catch (e: AssertionError) {
+      continue
     }
+    throw forNoneError(table.headers.values(), row.values())
   }
 }
 
@@ -509,9 +520,10 @@ fun <A, B, C, D, E, F, G, H, I, J, K, L> forNone(table: Table12<A, B, C, D, E, F
   for (row in table.rows) {
     try {
       fn(row.a, row.b, row.c, row.d, row.e, row.f, row.g, row.h, row.i, row.j, row.k, row.l)
-      throw error(table.headers.values(), row.values())
     } catch (e: AssertionError) {
+      continue
     }
+    throw forNoneError(table.headers.values(), row.values())
   }
 }
 
@@ -519,9 +531,10 @@ fun <A, B, C, D, E, F, G, H, I, J, K, L, M> forNone(table: Table13<A, B, C, D, E
   for (row in table.rows) {
     try {
       fn(row.a, row.b, row.c, row.d, row.e, row.f, row.g, row.h, row.i, row.j, row.k, row.l, row.m)
-      throw error(table.headers.values(), row.values())
     } catch (e: AssertionError) {
+      continue
     }
+    throw forNoneError(table.headers.values(), row.values())
   }
 }
 
@@ -529,9 +542,10 @@ fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N> forNone(table: Table14<A, B, C, D
   for (row in table.rows) {
     try {
       fn(row.a, row.b, row.c, row.d, row.e, row.f, row.g, row.h, row.i, row.j, row.k, row.l, row.m, row.n)
-      throw error(table.headers.values(), row.values())
     } catch (e: AssertionError) {
+      continue
     }
+    throw forNoneError(table.headers.values(), row.values())
   }
 }
 
@@ -539,9 +553,10 @@ fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O> forNone(table: Table15<A, B, C
   for (row in table.rows) {
     try {
       fn(row.a, row.b, row.c, row.d, row.e, row.f, row.g, row.h, row.i, row.j, row.k, row.l, row.m, row.n, row.o)
-      throw error(table.headers.values(), row.values())
     } catch (e: AssertionError) {
+      continue
     }
+    throw forNoneError(table.headers.values(), row.values())
   }
 }
 
@@ -549,9 +564,10 @@ fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P> forNone(table: Table16<A, B
   for (row in table.rows) {
     try {
       fn(row.a, row.b, row.c, row.d, row.e, row.f, row.g, row.h, row.i, row.j, row.k, row.l, row.m, row.n, row.o, row.p)
-      throw error(table.headers.values(), row.values())
     } catch (e: AssertionError) {
+      continue
     }
+    throw forNoneError(table.headers.values(), row.values())
   }
 }
 
@@ -559,9 +575,10 @@ fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q> forNone(table: Table17<A
   for (row in table.rows) {
     try {
       fn(row.a, row.b, row.c, row.d, row.e, row.f, row.g, row.h, row.i, row.j, row.k, row.l, row.m, row.n, row.o, row.p, row.q)
-      throw error(table.headers.values(), row.values())
     } catch (e: AssertionError) {
+      continue
     }
+    throw forNoneError(table.headers.values(), row.values())
   }
 }
 
@@ -569,9 +586,10 @@ fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R> forNone(table: Table1
   for (row in table.rows) {
     try {
       fn(row.a, row.b, row.c, row.d, row.e, row.f, row.g, row.h, row.i, row.j, row.k, row.l, row.m, row.n, row.o, row.p, row.q, row.r)
-      throw error(table.headers.values(), row.values())
     } catch (e: AssertionError) {
+      continue
     }
+    throw forNoneError(table.headers.values(), row.values())
   }
 }
 
@@ -579,9 +597,10 @@ fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S> forNone(table: Tab
   for (row in table.rows) {
     try {
       fn(row.a, row.b, row.c, row.d, row.e, row.f, row.g, row.h, row.i, row.j, row.k, row.l, row.m, row.n, row.o, row.p, row.q, row.r, row.s)
-      throw error(table.headers.values(), row.values())
     } catch (e: AssertionError) {
+      continue
     }
+    throw forNoneError(table.headers.values(), row.values())
   }
 }
 
@@ -589,9 +608,10 @@ fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T> forNone(table: 
   for (row in table.rows) {
     try {
       fn(row.a, row.b, row.c, row.d, row.e, row.f, row.g, row.h, row.i, row.j, row.k, row.l, row.m, row.n, row.o, row.p, row.q, row.r, row.s, row.t)
-      throw error(table.headers.values(), row.values())
     } catch (e: AssertionError) {
+      continue
     }
+    throw forNoneError(table.headers.values(), row.values())
   }
 }
 
@@ -599,9 +619,10 @@ fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U> forNone(tabl
   for (row in table.rows) {
     try {
       fn(row.a, row.b, row.c, row.d, row.e, row.f, row.g, row.h, row.i, row.j, row.k, row.l, row.m, row.n, row.o, row.p, row.q, row.r, row.s, row.t, row.u)
-      throw error(table.headers.values(), row.values())
     } catch (e: AssertionError) {
+      continue
     }
+    throw forNoneError(table.headers.values(), row.values())
   }
 }
 
@@ -609,9 +630,10 @@ fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V> forNone(t
   for (row in table.rows) {
     try {
       fn(row.a, row.b, row.c, row.d, row.e, row.f, row.g, row.h, row.i, row.j, row.k, row.l, row.m, row.n, row.o, row.p, row.q, row.r, row.s, row.t, row.u, row.v)
-      throw error(table.headers.values(), row.values())
     } catch (e: AssertionError) {
+      continue
     }
+    throw forNoneError(table.headers.values(), row.values())
   }
 }
 

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/tables/TableTestingTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/tables/TableTestingTest.kt
@@ -1,19 +1,10 @@
 package com.sksamuel.kotlintest.tables
 
+import io.kotlintest.*
 import io.kotlintest.matchers.string.contain
 import io.kotlintest.matchers.types.shouldNotBeInstanceOf
-import io.kotlintest.should
-import io.kotlintest.shouldBe
-import io.kotlintest.shouldNot
-import io.kotlintest.shouldNotBe
-import io.kotlintest.shouldThrow
 import io.kotlintest.specs.StringSpec
-import io.kotlintest.tables.MultiAssertionError
-import io.kotlintest.tables.forAll
-import io.kotlintest.tables.forNone
-import io.kotlintest.tables.headers
-import io.kotlintest.tables.row
-import io.kotlintest.tables.table
+import io.kotlintest.tables.*
 
 class TableTestingTest : StringSpec() {
   init {
@@ -57,7 +48,7 @@ class TableTestingTest : StringSpec() {
       }
     }
 
-    "numbers all be different using extension function" {
+    "numbers should all be different using extension function" {
 
       table(headers("a", "b"),
           row(1, 2),
@@ -65,6 +56,16 @@ class TableTestingTest : StringSpec() {
           row(5, 6)
       ).forNone { a, b ->
         a shouldBe b
+      }
+    }
+
+    "forNone should fail if any rows succeed" {
+      shouldThrow<AssertionError> {
+        table(headers("a", "b"),
+            row(1, 1)
+        ).forNone { a, b ->
+          a shouldBe b
+        }
       }
     }
 


### PR DESCRIPTION
Currently, `forNone` will never fail. If the callback succeeds, an `AssertionError` is thrown, but it's immediately caught by the try/catch that's meant to catch failures in the callback.

This PR also fixes the `between` matcher for Doubles, which was incorrectly passing its tests due to `forNone` not working.