### PR TITLE
Add soft assertions

### DIFF
--- a/doc/reference.md
+++ b/doc/reference.md
@@ -178,10 +178,10 @@ Soft Assertions
 Normally, assertions like `shouldBe` throw an exception when they fail.
 But sometimes you want to perform multiple assertions in a test, and
 would like to see all of the assertions that failed. KotlinTest provides
-the `verifyAll` function for this purpose.
+the `assertSoftly` function for this purpose.
 
 ```kotlin
-verifyAll {
+assertSoftly {
   foo shouldBe bar
   foo should contain(baz)
 }

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -172,6 +172,33 @@ fun String.shouldNotContainFoo() = this shouldNot containFoo()
 
 
 
+Soft Assertions
+---------------
+
+Normally, assertions like `shouldBe` throw an exception when they fail.
+But sometimes you want to perform multiple assertions in a test, and
+would like to see all of the assertions that failed. KotlinTest provides
+the `verifyAll` function for this purpose.
+
+```kotlin
+verifyAll {
+  foo shouldBe bar
+  foo should contain(baz)
+}
+```
+
+If any assertions inside the block failed, the test will continue to
+run. All failures will be reported in a single exception at the end of
+the block.
+
+
+
+
+
+
+
+
+
 Exceptions
 ----------
 
@@ -347,7 +374,7 @@ object ProjectConfig : AbstractProjectConfig() {
 }
 ```
 
-### Project Extensions 
+### Project Extensions
 _(Project Extensions are DEPRECATED in favour of Test Listeners.)_
 
 Many types of reusable extensions can be registered in the `ProjectConfig`. Where appropriate these will be executed for all
@@ -590,7 +617,7 @@ One Instance Per Test
 ---------------------
 
 All specs allow you to instruct the test engine to create a new instance of the Spec for every test case.
- 
+
 To do this simply override the `isInstancePerTest()` function returning true:
 
 ```kotlin
@@ -812,7 +839,7 @@ can control which tests are run:
 * If only `kotlintest.tags.exclude` are specified, only tests without that tag are run (untagged tests *are* run).
 * If you provide more than one tag for `kotlintest.tags.include` or `kotlintest.tags.exclude`, a test case with at least one of the given tags is included/excluded.
 
-Provide the simple names of tag object (without package) when you run the tests. 
+Provide the simple names of tag object (without package) when you run the tests.
 Please pay attention to the use of upper case and lower case! If two tag objects have the same simple name (in different name spaces) they are treated as the same tag.
 
 Example: To run only test tagged with `Linux`, but not tagged with `Database`, you would invoke
@@ -853,7 +880,7 @@ class StringSpecExample : StringSpec() {
 }
 ```
 
-Resources that should be closed this way must implement [`java.io.Closeable`](http://docs.oracle.com/javase/6/docs/api/java/io/Closeable.html). Closing is performed in  
+Resources that should be closed this way must implement [`java.io.Closeable`](http://docs.oracle.com/javase/6/docs/api/java/io/Closeable.html). Closing is performed in
 reversed order of declaration after the return of the last spec interceptor.
 
 
@@ -883,10 +910,10 @@ class MyTests : StringSpec({
 
 ### Eventually <a name="eventually"></a>
 
-When testing non-deterministic code, it's handy to be able to say "I expect these assertions to pass in a certain time". 
-Sometimes you can do a Thread.sleep but this is bad as you have to set a timeout that's high enough so that it won't expire prematurely. 
-Plus it means that your test will sit around even if the code completes quickly. Another common method is to use countdown latches. 
-KotlinTest provides the `Eventually` mixin, which gives you the `eventually` function which will repeatedly test the code until it either passes, 
+When testing non-deterministic code, it's handy to be able to say "I expect these assertions to pass in a certain time".
+Sometimes you can do a Thread.sleep but this is bad as you have to set a timeout that's high enough so that it won't expire prematurely.
+Plus it means that your test will sit around even if the code completes quickly. Another common method is to use countdown latches.
+KotlinTest provides the `Eventually` mixin, which gives you the `eventually` function which will repeatedly test the code until it either passes,
 or the timeout is reached. This is perfect for nondeterministic code. For example:
 
 ```kotlin

--- a/kotlintest-assertions/src/main/kotlin/io/kotlintest/ErrorCollector.kt
+++ b/kotlintest-assertions/src/main/kotlin/io/kotlintest/ErrorCollector.kt
@@ -1,0 +1,39 @@
+package io.kotlintest
+
+import io.kotlintest.Failures.removeKotlintestElementsFromStacktrace
+import io.kotlintest.tables.MultiAssertionError
+
+@PublishedApi
+internal object ErrorCollector {
+  private val failures = object : ThreadLocal<MutableList<Throwable>>() {
+    override fun initialValue(): MutableList<Throwable> = mutableListOf()
+  }
+  @PublishedApi
+  internal val shouldCollectErrors = object : ThreadLocal<Boolean>() {
+    override fun initialValue() = false
+  }
+
+  @PublishedApi
+  internal fun collectOrThrow(error: Throwable) {
+    if (shouldCollectErrors.get()) {
+      failures.get().add(error)
+    } else {
+      throw error
+    }
+  }
+
+  @PublishedApi
+  internal fun throwCollectedErrors() {
+    shouldCollectErrors.set(false)
+    val failures = this.failures.get()
+    if (failures.isNotEmpty()) {
+      this.failures.set(mutableListOf())
+      if (failures.size == 1) throw failures[0]
+      val error = MultiAssertionError(failures)
+      if (Failures.shouldRemoveKotlintestElementsFromStacktrace) {
+        removeKotlintestElementsFromStacktrace(error)
+      }
+      throw error
+    }
+  }
+}

--- a/kotlintest-assertions/src/main/kotlin/io/kotlintest/dsl.kt
+++ b/kotlintest-assertions/src/main/kotlin/io/kotlintest/dsl.kt
@@ -13,7 +13,7 @@ import io.kotlintest.matchers.ToleranceMatcher
  * }
  * ```
  */
-inline fun <T> verifyAll(assertions: () -> T): T {
+inline fun <T> assertSoftly(assertions: () -> T): T {
   // Handle the edge case of nested calls to this function by only calling throwCollectedErrors in the
   // outermost verifyAll block
   if (ErrorCollector.shouldCollectErrors.get()) return assertions()

--- a/kotlintest-assertions/src/main/kotlin/io/kotlintest/dsl.kt
+++ b/kotlintest-assertions/src/main/kotlin/io/kotlintest/dsl.kt
@@ -2,6 +2,27 @@ package io.kotlintest
 
 import io.kotlintest.matchers.ToleranceMatcher
 
+/**
+ * Run multiple assertions, collecting any failures into a single exception that is thrown at the end of the
+ * block.
+ *
+ * ```
+ * verifyAll {
+ *   foo shouldBe bar
+ *   baz.shouldBeLessThan(qux)
+ * }
+ * ```
+ */
+inline fun <T> verifyAll(assertions: () -> T): T {
+  // Handle the edge case of nested calls to this function by only calling throwCollectedErrors in the
+  // outermost verifyAll block
+  if (ErrorCollector.shouldCollectErrors.get()) return assertions()
+  ErrorCollector.shouldCollectErrors.set(true)
+  return assertions().apply {
+    ErrorCollector.throwCollectedErrors()
+  }
+}
+
 fun <T> be(expected: T) = equalityMatcher(expected)
 fun <T> equalityMatcher(expected: T) = object : Matcher<T> {
   override fun test(value: T): Result {
@@ -44,9 +65,9 @@ infix fun <T, U : T> T.shouldBe(any: U?) {
     is Matcher<*> -> should(any as Matcher<T>)
     else -> {
       if (this == null && any != null)
-        throw equalsError(any, this)
+        ErrorCollector.collectOrThrow(equalsError(any, this))
       if (!compare(this, any))
-        throw equalsError(any, this)
+        ErrorCollector.collectOrThrow(equalsError(any, this))
     }
   }
 }
@@ -65,7 +86,7 @@ infix fun <T> T.shouldHave(matcher: Matcher<T>) = should(matcher)
 infix fun <T> T.should(matcher: Matcher<T>) {
   val result = matcher.test(this)
   if (!result.passed)
-    throw Failures.failure(result.failureMessage)
+    ErrorCollector.collectOrThrow(Failures.failure(result.failureMessage))
 }
 
 infix fun <T> T.shouldNotHave(matcher: Matcher<T>) = shouldNot(matcher)
@@ -82,63 +103,63 @@ infix fun BooleanArray?.shouldBe(other: BooleanArray?) {
   val expected = other?.asList()
   val actual = this?.asList()
   if (actual != expected)
-    throw equalsError(expected, actual)
+    ErrorCollector.collectOrThrow(equalsError(expected, actual))
 }
 
 infix fun IntArray?.shouldBe(other: IntArray?) {
   val expected = other?.asList()
   val actual = this?.asList()
   if (actual != expected)
-    throw equalsError(expected, actual)
+    ErrorCollector.collectOrThrow(equalsError(expected, actual))
 }
 
 infix fun ShortArray?.shouldBe(other: ShortArray?) {
   val expected = other?.asList()
   val actual = this?.asList()
   if (actual != expected)
-    throw equalsError(expected, actual)
+    ErrorCollector.collectOrThrow(equalsError(expected, actual))
 }
 
 infix fun FloatArray?.shouldBe(other: FloatArray?) {
   val expected = other?.asList()
   val actual = this?.asList()
   if (actual != expected)
-    throw equalsError(expected, actual)
+    ErrorCollector.collectOrThrow(equalsError(expected, actual))
 }
 
 infix fun DoubleArray?.shouldBe(other: DoubleArray?) {
   val expected = other?.asList()
   val actual = this?.asList()
   if (actual != expected)
-    throw equalsError(expected, actual)
+    ErrorCollector.collectOrThrow(equalsError(expected, actual))
 }
 
 infix fun LongArray?.shouldBe(other: LongArray?) {
   val expected = other?.asList()
   val actual = this?.asList()
   if (actual != expected)
-    throw equalsError(expected, actual)
+    ErrorCollector.collectOrThrow(equalsError(expected, actual))
 }
 
 infix fun ByteArray?.shouldBe(other: ByteArray?) {
   val expected = other?.asList()
   val actual = this?.asList()
   if (actual != expected)
-    throw equalsError(expected, actual)
+    ErrorCollector.collectOrThrow(equalsError(expected, actual))
 }
 
 infix fun CharArray?.shouldBe(other: CharArray?) {
   val expected = other?.asList()
   val actual = this?.asList()
   if (actual != expected)
-    throw equalsError(expected, actual)
+    ErrorCollector.collectOrThrow(equalsError(expected, actual))
 }
 
 infix fun <T> Array<T>?.shouldBe(other: Array<T>?) {
   val expected = other?.asList()
   val actual = this?.asList()
   if (actual != expected)
-    throw equalsError(expected, actual)
+    ErrorCollector.collectOrThrow(equalsError(expected, actual))
 }
 
 private fun equalsError(expected: Any?, actual: Any?): Throwable {

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/matchers/SoftAssertionsTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/matchers/SoftAssertionsTest.kt
@@ -18,14 +18,14 @@ import io.kotlintest.shouldNot
 import io.kotlintest.shouldNotBe
 import io.kotlintest.shouldThrow
 import io.kotlintest.specs.FreeSpec
-import io.kotlintest.verifyAll
+import io.kotlintest.assertSoftly
 
 class SoftAssertionsTest : FreeSpec({
 
-  "verifyAll" - {
+  "assertSoftly" - {
 
     "passes when all assertions pass" {
-      verifyAll {
+      assertSoftly {
         1 shouldBe 1
         "foo" shouldBe "foo"
       }
@@ -33,7 +33,7 @@ class SoftAssertionsTest : FreeSpec({
 
     "rethrows single failures" {
       shouldThrow<AssertionError> {
-        verifyAll {
+        assertSoftly {
           1 shouldBe 2
         }
       }.message shouldBe "expected: 2 but was: 1"
@@ -41,7 +41,7 @@ class SoftAssertionsTest : FreeSpec({
 
     "groups multiple failures" {
       shouldThrow<AssertionError> {
-        verifyAll {
+        assertSoftly {
           1 shouldBe 2
           1 shouldBe 1 // should pass
           "foo" shouldNotBe "foo"
@@ -54,7 +54,7 @@ class SoftAssertionsTest : FreeSpec({
 
     "works with all array types" {
       shouldThrow<AssertionError> {
-        verifyAll {
+        assertSoftly {
           booleanArrayOf(true) shouldBe booleanArrayOf(false)
           intArrayOf(1) shouldBe intArrayOf(2)
           shortArrayOf(1) shouldBe shortArrayOf(2)
@@ -73,7 +73,7 @@ class SoftAssertionsTest : FreeSpec({
 
     "works with any matcher" {
       shouldThrow<AssertionError> {
-        verifyAll {
+        assertSoftly {
           1 should beLessThan(0)
           "foobar" shouldNot endWith("bar")
           1 shouldBe positive() // should pass
@@ -89,7 +89,7 @@ class SoftAssertionsTest : FreeSpec({
 
     "works with extension functions" {
       shouldThrow<AssertionError> {
-        verifyAll {
+        assertSoftly {
           1.shouldBeLessThan(0)
           "foobar".shouldNotEndWith("bar")
           1.shouldBePositive() // should pass
@@ -104,9 +104,9 @@ class SoftAssertionsTest : FreeSpec({
 
     "can be nested" {
       shouldThrow<AssertionError> {
-        verifyAll {
+        assertSoftly {
           1 shouldBe 2
-          verifyAll {
+          assertSoftly {
             2 shouldBe 3
           }
         }

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/matchers/SoftAssertionsTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/matchers/SoftAssertionsTest.kt
@@ -1,0 +1,119 @@
+package com.sksamuel.kotlintest.matchers
+
+import io.kotlintest.matchers.beLessThan
+import io.kotlintest.matchers.collections.containExactly
+import io.kotlintest.matchers.collections.shouldNotContainExactly
+import io.kotlintest.matchers.doubles.negative
+import io.kotlintest.matchers.doubles.positive
+import io.kotlintest.matchers.doubles.shouldBeNegative
+import io.kotlintest.matchers.endWith
+import io.kotlintest.matchers.haveKey
+import io.kotlintest.matchers.numerics.shouldBeLessThan
+import io.kotlintest.matchers.numerics.shouldBePositive
+import io.kotlintest.matchers.string.contain
+import io.kotlintest.matchers.string.shouldNotEndWith
+import io.kotlintest.should
+import io.kotlintest.shouldBe
+import io.kotlintest.shouldNot
+import io.kotlintest.shouldNotBe
+import io.kotlintest.shouldThrow
+import io.kotlintest.specs.FreeSpec
+import io.kotlintest.verifyAll
+
+class SoftAssertionsTest : FreeSpec({
+
+  "verifyAll" - {
+
+    "passes when all assertions pass" {
+      verifyAll {
+        1 shouldBe 1
+        "foo" shouldBe "foo"
+      }
+    }
+
+    "rethrows single failures" {
+      shouldThrow<AssertionError> {
+        verifyAll {
+          1 shouldBe 2
+        }
+      }.message shouldBe "expected: 2 but was: 1"
+    }
+
+    "groups multiple failures" {
+      shouldThrow<AssertionError> {
+        verifyAll {
+          1 shouldBe 2
+          1 shouldBe 1 // should pass
+          "foo" shouldNotBe "foo"
+        }
+      }.let {
+        it.message should contain("1) expected: 2 but was: 1")
+        it.message should contain("2) \"foo\" should not equal \"foo\"")
+      }
+    }
+
+    "works with all array types" {
+      shouldThrow<AssertionError> {
+        verifyAll {
+          booleanArrayOf(true) shouldBe booleanArrayOf(false)
+          intArrayOf(1) shouldBe intArrayOf(2)
+          shortArrayOf(1) shouldBe shortArrayOf(2)
+          floatArrayOf(1f) shouldBe floatArrayOf(2f)
+          doubleArrayOf(1.0) shouldBe doubleArrayOf(2.0)
+          longArrayOf(1) shouldBe longArrayOf(2)
+          byteArrayOf(1) shouldBe byteArrayOf(2)
+          charArrayOf('a') shouldBe charArrayOf('b')
+          arrayOf("foo") shouldBe arrayOf("bar")
+        }
+      }.let {
+        it.message should contain("9) expected: [\"bar\"] but was: [\"foo\"]")
+        it.message shouldNot contain("10) ")
+      }
+    }
+
+    "works with any matcher" {
+      shouldThrow<AssertionError> {
+        verifyAll {
+          1 should beLessThan(0)
+          "foobar" shouldNot endWith("bar")
+          1 shouldBe positive() // should pass
+          1.0 shouldBe negative()
+          listOf(1) shouldNot containExactly(1)
+          mapOf(1 to 2) should haveKey(3)
+        }
+      }.let {
+        it.message should contain("5) Map should contain key 3")
+        it.message shouldNot contain("6) ")
+      }
+    }
+
+    "works with extension functions" {
+      shouldThrow<AssertionError> {
+        verifyAll {
+          1.shouldBeLessThan(0)
+          "foobar".shouldNotEndWith("bar")
+          1.shouldBePositive() // should pass
+          1.0.shouldBeNegative()
+          listOf(1).shouldNotContainExactly(1)
+        }
+      }.let {
+        it.message should contain("4) Collection should not be exactly [1]")
+        it.message shouldNot contain("5) ")
+      }
+    }
+
+    "can be nested" {
+      shouldThrow<AssertionError> {
+        verifyAll {
+          1 shouldBe 2
+          verifyAll {
+            2 shouldBe 3
+          }
+        }
+      }.let {
+        it.message should contain("1) expected: 2 but was: 1")
+        it.message should contain("2) expected: 3 but was: 2")
+      }
+    }
+  }
+})


### PR DESCRIPTION
This PR adds the ability to perform multiple assertions in a block without the test stopping on the first failed assertion. The `verifyAll` function takes a lambda, and any assertion failures inside the block will be gathered, then thrown when the block exits.

Many other testing framework have some version of this functionality:

* [AssertJ](https://joel-costigliola.github.io/assertj/assertj-core-features-highlight.html#soft-assertions)
* [TestNG](https://jitpack.io/com/github/cbeust/testng/master/javadoc/org/testng/asserts/SoftAssert.html)
* [Spock](http://spockframework.org/spock/docs/1.1/all_in_one.html#_what_s_new_in_this_release_4)

The implementation works by changing the `should*` dsl functions to send their failures to an `ErrorCollector`, which will gather the errors when inside a `verifyAll` block, or throw the error immediately otherwise. The collected errors are held in thread-local storage to prevent race conditions in the unlikely case that multiple threads invoke `verifyAll` concurrently.

Existing assertion functions that take a lambda often rely on throwing an exception for control flow, and so will continue to throw immediately instead of collecting their errors. This includes `eventually`, `shouldThrow*`, `shouldTimeout`, and property and table testing.