### PR TITLE
Fix beLeft is comparing against Either.Right instead of Either.Left

### DIFF
--- a/kotlintest-assertions-arrow/src/main/kotlin/io/kotlintest/assertions/arrow/either/matchers.kt
+++ b/kotlintest-assertions-arrow/src/main/kotlin/io/kotlintest/assertions/arrow/either/matchers.kt
@@ -13,7 +13,7 @@ fun <T> beRight() = beInstanceOf2<Either<Any, T>, Either.Right<Any, T>>()
 
 fun <T> Either<T, Any>.shouldBeLeft() = this should beLeft()
 fun <T> Either<T, Any>.shouldNotBeLeft() = this shouldNot beLeft()
-fun <T> beLeft() = beInstanceOf2<Either<T, Any>, Either.Right<T, Any>>()
+fun <T> beLeft() = beInstanceOf2<Either<T, Any>, Either.Left<T, Any>>()
 
 fun <B> Either<Any, B>.shouldBeRight(b: B) = this should beRight(b)
 fun <B> Either<Any, B>.shouldNotBeRight(b: B) = this shouldNot beRight(b)

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/assertions/arrow/EitherMatchersTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/assertions/arrow/EitherMatchersTest.kt
@@ -41,7 +41,7 @@ class EitherMatchersTest : WordSpec() {
 
     "Either should beLeft()" should {
       "test that the either is of type left" {
-        Either.right("boo").shouldBeLeft()
+        Either.left("boo").shouldBeLeft()
       }
     }
 


### PR DESCRIPTION
This PR should fix a bug where is comparing against Either.Right instead of comparing to Either.Left type.