### PR TITLE
Update: make use of `limit` argument to `List<E>.joinToString()` (sim…

### DIFF
--- a/kotlintest-assertions-arrow/src/main/kotlin/io/kotlintest/assertions/arrow/nel/matchers.kt
+++ b/kotlintest-assertions-arrow/src/main/kotlin/io/kotlintest/assertions/arrow/nel/matchers.kt
@@ -81,8 +81,8 @@ fun <T> containAll(vararg ts: T) = containAll(ts.asList())
 fun <T> containAll(ts: List<T>): Matcher<NonEmptyList<T>> = object : Matcher<NonEmptyList<T>> {
   override fun test(value: NonEmptyList<T>) = Result(
       ts.all { value.contains(it) },
-      "NonEmptyList should contain all of ${ts.take(10).joinToString(",")}",
-      "NonEmptyList should not contain all of ${ts.take(10).joinToString(",")}"
+      "NonEmptyList should contain all of ${ts.joinToString(",", limit=10)}",
+      "NonEmptyList should not contain all of ${ts.joinToString(",", limit=10)}"
   )
 }
 
@@ -112,7 +112,7 @@ fun <T : Comparable<T>> NonEmptyList<T>.shouldNotBeSorted() = this shouldNot beS
 fun <T : Comparable<T>> beSorted(): Matcher<NonEmptyList<T>> = object : Matcher<NonEmptyList<T>> {
   override fun test(value: NonEmptyList<T>): Result {
     val passed = value.all.sorted() == value.all
-    val snippet = if (value.size <= 10) value.all.joinToString(",") else value.all.take(10).joinToString(",") + "..."
+    val snippet = value.all.joinToString(",", limit=10)
     return Result(
         passed,
         "NonEmptyList $snippet should be sorted",

--- a/kotlintest-assertions/src/main/kotlin/io/kotlintest/matchers/CollectionMatchers.kt
+++ b/kotlintest-assertions/src/main/kotlin/io/kotlintest/matchers/CollectionMatchers.kt
@@ -33,8 +33,8 @@ fun <T> containAll(vararg ts: T) = containAll(ts.asList())
 fun <T> containAll(ts: Collection<T>): Matcher<Collection<T>> = object : Matcher<Collection<T>> {
   override fun test(value: Collection<T>) = Result(
       ts.all { value.contains(it) },
-      "Collection should contain all of ${ts.take(10).joinToString(",")}",
-      "Collection should not contain all of ${ts.take(10).joinToString(",")}"
+      "Collection should contain all of ${ts.joinToString(",", limit=10)}",
+      "Collection should not contain all of ${ts.joinToString(",", limit=10)}"
   )
 }
 
@@ -74,7 +74,7 @@ fun <T : Comparable<T>> beSorted(): Matcher<List<T>> = sorted()
 fun <T : Comparable<T>> sorted(): Matcher<List<T>> = object : Matcher<List<T>> {
   override fun test(value: List<T>): Result {
     val failure = value.withIndex().firstOrNull { (i, it) -> i != value.lastIndex && it > value[i+1] }
-    val snippet = if (value.size <= 10) value.joinToString(",") else value.take(10).joinToString(",", postfix =  "...")
+    val snippet = value.joinToString(",", limit = 10)
     val elementMessage = when (failure) {
         null -> ""
         else -> ". Element ${failure.value} at index ${failure.index} was greater than element ${value[failure.index+1]}"


### PR DESCRIPTION
There are a couple places in the code where the use of the `limit` argument to `List<E>.joinToString()` would either simplify the code or add more informative output. 