### PR TITLE
Use unambiguous representations in collection matchers

### DIFF
--- a/kotlintest-assertions/src/main/kotlin/io/kotlintest/dsl.kt
+++ b/kotlintest-assertions/src/main/kotlin/io/kotlintest/dsl.kt
@@ -209,7 +209,7 @@ private fun callPublicConstructor(className: String, parameterTypes: Array<Class
 }
 
 /** Return a string representation of [obj] that is less ambiguous than `toString` */
-private fun stringRepr(obj: Any?): String = when (obj) {
+internal fun stringRepr(obj: Any?): String = when (obj) {
   is Float -> "${obj}f"
   is Long -> "${obj}L"
   is Char -> "'$obj'"

--- a/kotlintest-assertions/src/main/kotlin/io/kotlintest/matchers/CollectionMatchers.kt
+++ b/kotlintest-assertions/src/main/kotlin/io/kotlintest/matchers/CollectionMatchers.kt
@@ -3,6 +3,7 @@ package io.kotlintest.matchers
 import io.kotlintest.Matcher
 import io.kotlintest.Result
 import io.kotlintest.neverNullMatcher
+import io.kotlintest.stringRepr
 
 fun <T> haveSizeMatcher(size: Int) = object : Matcher<Collection<T>> {
   override fun test(value: Collection<T>) =
@@ -33,8 +34,8 @@ fun <T> containAll(vararg ts: T) = containAll(ts.asList())
 fun <T> containAll(ts: Collection<T>): Matcher<Collection<T>> = object : Matcher<Collection<T>> {
   override fun test(value: Collection<T>) = Result(
       ts.all { value.contains(it) },
-      "Collection should contain all of ${ts.joinToString(",", limit=10)}",
-      "Collection should not contain all of ${ts.joinToString(",", limit=10)}"
+      "Collection should contain all of ${ts.joinToString(", ", limit = 10) { stringRepr(it) }}",
+      "Collection should not contain all of ${ts.joinToString(", ", limit = 10) { stringRepr(it) }}"
   )
 }
 
@@ -52,8 +53,8 @@ fun <T> containsInOrder(subsequence: List<T>): Matcher<Collection<T>?> = neverNu
 
   Result(
       subsequenceIndex == subsequence.size,
-      "[$actual] did not contain the elements [$subsequence] in order",
-      "[$actual] should not contain the elements [$subsequence] in order"
+      "${stringRepr(actual)} did not contain the elements ${stringRepr(subsequence)} in order",
+      "${stringRepr(actual)} should not contain the elements ${stringRepr(subsequence)} in order"
   )
 }
 

--- a/kotlintest-assertions/src/main/kotlin/io/kotlintest/matchers/collections/matchers.kt
+++ b/kotlintest-assertions/src/main/kotlin/io/kotlintest/matchers/collections/matchers.kt
@@ -1,17 +1,12 @@
 package io.kotlintest.matchers.collections
 
-import io.kotlintest.Matcher
-import io.kotlintest.Result
+import io.kotlintest.*
 import io.kotlintest.matchers.beEmpty
 import io.kotlintest.matchers.beSorted
 import io.kotlintest.matchers.containAll
 import io.kotlintest.matchers.containsInOrder
 import io.kotlintest.matchers.haveSize
 import io.kotlintest.matchers.singleElement
-import io.kotlintest.neverNullMatcher
-import io.kotlintest.should
-import io.kotlintest.shouldHave
-import io.kotlintest.shouldNot
 
 fun <T> Collection<T>.shouldContainOnlyNulls() = this should containOnlyNulls()
 fun <T> Collection<T>.shouldNotContainOnlyNulls() = this shouldNot containOnlyNulls()
@@ -49,8 +44,8 @@ fun <T, L : List<T>> haveElementAt(index: Int, element: T) = object : Matcher<L>
   override fun test(value: L) =
       Result(
           value[index] == element,
-          "Collection should contain $element at index $index",
-          "Collection should not contain $element at index $index"
+          "Collection should contain ${stringRepr(element)} at index $index",
+          "Collection should not contain ${stringRepr(element)} at index $index"
       )
 }
 
@@ -70,8 +65,8 @@ fun <T, C : Collection<T>> C.shouldNotContain(t: T) = this shouldNot contain(t)
 fun <T, C : Collection<T>> contain(t: T) = object : Matcher<C> {
   override fun test(value: C) = Result(
       value.contains(t),
-      "Collection should contain element $t",
-      "Collection should not contain element $t"
+      "Collection should contain element ${stringRepr(t)}",
+      "Collection should not contain element ${stringRepr(t)}"
   )
 }
 
@@ -85,8 +80,8 @@ fun <T, C : Collection<T>> containExactly(expected: C): Matcher<C?> = neverNullM
   val passed = value.size == expected.size && value.zip(expected) { a, b -> a == b }.all { it }
   Result(
       passed,
-      "Collection should be exactly $expected but was $value",
-      "Collection should not be exactly $expected"
+      "Collection should be exactly ${stringRepr(expected)} but was ${stringRepr(value)}",
+      "Collection should not be exactly ${stringRepr(expected)}"
   )
 }
 
@@ -100,8 +95,8 @@ fun <T, C : Collection<T>> containExactlyInAnyOrder(expected: C): Matcher<C?> = 
   val passed = value.size == expected.size && expected.all { value.contains(it) }
   Result(
       passed,
-      "Collection should contain $expected in any order, but was $value",
-      "Collection should not contain exactly $expected in any order"
+      "Collection should contain ${stringRepr(expected)} in any order, but was ${stringRepr(value)}",
+      "Collection should not contain exactly ${stringRepr(expected)} in any order"
   )
 }
 

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/ExposeTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/ExposeTest.kt
@@ -32,7 +32,7 @@ class ExposeTest : WordSpec() {
         shouldThrowAny {
           extracting(persons) { name }
               .shouldContainAll("<Some name that is wrong>")
-        }.message shouldBe "Collection should contain all of <Some name that is wrong>"
+        }.message shouldBe "Collection should contain all of \"<Some name that is wrong>\""
       }
 
     }

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/matchers/collections/CollectionMatchersTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/matchers/collections/CollectionMatchersTest.kt
@@ -7,6 +7,7 @@ import io.kotlintest.matchers.containsInOrder
 import io.kotlintest.matchers.haveSize
 import io.kotlintest.matchers.singleElement
 import io.kotlintest.matchers.sorted
+import io.kotlintest.matchers.string.shouldContain
 import io.kotlintest.should
 import io.kotlintest.shouldBe
 import io.kotlintest.shouldFail
@@ -20,8 +21,8 @@ import java.util.*
 class CollectionMatchersTest : WordSpec() {
 
   val countdown = (10 downTo 0).toList()
-  val asc = { a:Int, b:Int -> a - b }
-  val desc = { a:Int, b:Int -> b - a }
+  val asc = { a: Int, b: Int -> a - b }
+  val desc = { a: Int, b: Int -> b - a }
 
   init {
 
@@ -47,28 +48,28 @@ class CollectionMatchersTest : WordSpec() {
       }
     }
 
-	"sortedWith" should {
-		val items = listOf(
-			1 to "I",
-			2 to "II",
-			4 to "IV",
-			5 to "V",
-			6 to "VI",
-			9 to "IX",
-			10 to "X"
-		)
-	
-		"work on non-Comparable given a Comparator" {
-			items.shouldBeSortedWith(object : Comparator<Pair<Int, String>> {
-				override fun compare(a:Pair<Int, String>, b:Pair<Int, String>): Int = asc(a.first, b.first)
-			})
-		}
+    "sortedWith" should {
+      val items = listOf(
+          1 to "I",
+          2 to "II",
+          4 to "IV",
+          5 to "V",
+          6 to "VI",
+          9 to "IX",
+          10 to "X"
+      )
 
-		"work on non-Comparable given a compare function" {
-			items.shouldBeSortedWith { a, b -> asc(a.first, b.first) }
-		}
-	}
-	
+      "work on non-Comparable given a Comparator" {
+        items.shouldBeSortedWith(object : Comparator<Pair<Int, String>> {
+          override fun compare(a: Pair<Int, String>, b: Pair<Int, String>): Int = asc(a.first, b.first)
+        })
+      }
+
+      "work on non-Comparable given a compare function" {
+        items.shouldBeSortedWith { a, b -> asc(a.first, b.first) }
+      }
+    }
+
     "haveElementAt" should {
       "test that a collection contains the specified element at the given index" {
         listOf("a", "b", "c") should haveElementAt(1, "b")
@@ -293,6 +294,7 @@ class CollectionMatchersTest : WordSpec() {
         }
         col should contain(2)
       }
+
       "support type inference for subtypes of collection" {
         val tests = listOf(
             TestSealed.Test1("test1"),
@@ -300,6 +302,12 @@ class CollectionMatchersTest : WordSpec() {
         )
         tests should contain(TestSealed.Test1("test1"))
         tests.shouldContain(TestSealed.Test2(2))
+      }
+
+      "print errors unambiguously"  {
+        shouldThrow<AssertionError> {
+          listOf<Any>(1, 2).shouldContain(listOf<Any>(1L, 2L))
+        }.message shouldBe "Collection should contain element [1L, 2L]"
       }
     }
 
@@ -324,6 +332,12 @@ class CollectionMatchersTest : WordSpec() {
           actual.shouldContainExactly(3, 2, 1)
         }
       }
+
+      "print errors unambiguously"  {
+        shouldThrow<AssertionError> {
+          listOf<Any>(1L, 2L).shouldContainExactly(listOf<Any>(1, 2))
+        }.message shouldBe "Collection should be exactly [1, 2] but was [1L, 2L]"
+      }
     }
 
     "containExactlyInAnyOrder" should {
@@ -342,6 +356,12 @@ class CollectionMatchersTest : WordSpec() {
         shouldThrow<AssertionError> {
           actual should containExactlyInAnyOrder(1, 2, 3, 4)
         }
+      }
+
+      "print errors unambiguously"  {
+        shouldThrow<AssertionError> {
+          listOf<Any>(1L, 2L).shouldContainExactlyInAnyOrder(listOf<Any>(1, 2))
+        }.message shouldBe "Collection should contain [1, 2] in any order, but was [1L, 2L]"
       }
     }
 
@@ -429,6 +449,11 @@ class CollectionMatchersTest : WordSpec() {
         val actual = listOf(5, 3, 1, 2, 4, 2)
         actual should containsInOrder(3, 2, 2)
       }
+      "print errors unambiguously"  {
+        shouldThrow<AssertionError> {
+          listOf<Number>(1L, 2L) should containsInOrder(listOf<Number>(1, 2))
+        }.message shouldBe "[1L, 2L] did not contain the elements [1, 2] in order"
+      }
     }
 
     "containsAll" should {
@@ -465,6 +490,11 @@ class CollectionMatchersTest : WordSpec() {
         shouldThrow<AssertionError> {
           col should containAll(3, 2, 0)
         }
+      }
+      "print errors unambiguously"  {
+        shouldThrow<AssertionError> {
+          listOf<Number>(1, 2).shouldContainAll(listOf<Number>(1L, 2L))
+        }.message shouldBe "Collection should contain all of 1L, 2L"
       }
     }
   }


### PR DESCRIPTION
I recently ran into some confusing output when comparing a list of `Int`s with a list of `Long`s. This PR uses the existing `stringRepr` function (used in equality comparisons) in the collection matchers in order to print values unambiguously.