### PR TITLE
Fix shouldBe on arrays without static types

### DIFF
--- a/kotlintest-assertions/src/main/kotlin/io/kotlintest/dsl.kt
+++ b/kotlintest-assertions/src/main/kotlin/io/kotlintest/dsl.kt
@@ -55,7 +55,22 @@ private fun compare(a: Any?, b: Any?): Boolean {
       is Int -> a == b.toLong()
       else -> a == b
     }
-    else -> a == b
+    else -> makeComparable(a) == makeComparable(b)
+  }
+}
+
+private fun makeComparable(any: Any?): Any? {
+  return when (any) {
+    is BooleanArray -> any.asList()
+    is IntArray -> any.asList()
+    is ShortArray -> any.asList()
+    is FloatArray -> any.asList()
+    is DoubleArray -> any.asList()
+    is LongArray -> any.asList()
+    is ByteArray -> any.asList()
+    is CharArray -> any.asList()
+    is Array<*> -> any.asList()
+    else -> any
   }
 }
 
@@ -64,10 +79,11 @@ infix fun <T, U : T> T.shouldBe(any: U?) {
   when (any) {
     is Matcher<*> -> should(any as Matcher<T>)
     else -> {
-      if (this == null && any != null)
+      if (this == null && any != null) {
         ErrorCollector.collectOrThrow(equalsError(any, this))
-      if (!compare(this, any))
+      } else if (!compare(this, any)) {
         ErrorCollector.collectOrThrow(equalsError(any, this))
+      }
     }
   }
 }
@@ -96,71 +112,6 @@ infix fun <T> T.should(matcher: (T) -> Unit) = matcher(this)
 
 
 // -- specialized overrides of shouldBe --
-
-infix fun Double?.shouldBe(other: Double?) = should(ToleranceMatcher(other, 0.0))
-
-infix fun BooleanArray?.shouldBe(other: BooleanArray?) {
-  val expected = other?.asList()
-  val actual = this?.asList()
-  if (actual != expected)
-    ErrorCollector.collectOrThrow(equalsError(expected, actual))
-}
-
-infix fun IntArray?.shouldBe(other: IntArray?) {
-  val expected = other?.asList()
-  val actual = this?.asList()
-  if (actual != expected)
-    ErrorCollector.collectOrThrow(equalsError(expected, actual))
-}
-
-infix fun ShortArray?.shouldBe(other: ShortArray?) {
-  val expected = other?.asList()
-  val actual = this?.asList()
-  if (actual != expected)
-    ErrorCollector.collectOrThrow(equalsError(expected, actual))
-}
-
-infix fun FloatArray?.shouldBe(other: FloatArray?) {
-  val expected = other?.asList()
-  val actual = this?.asList()
-  if (actual != expected)
-    ErrorCollector.collectOrThrow(equalsError(expected, actual))
-}
-
-infix fun DoubleArray?.shouldBe(other: DoubleArray?) {
-  val expected = other?.asList()
-  val actual = this?.asList()
-  if (actual != expected)
-    ErrorCollector.collectOrThrow(equalsError(expected, actual))
-}
-
-infix fun LongArray?.shouldBe(other: LongArray?) {
-  val expected = other?.asList()
-  val actual = this?.asList()
-  if (actual != expected)
-    ErrorCollector.collectOrThrow(equalsError(expected, actual))
-}
-
-infix fun ByteArray?.shouldBe(other: ByteArray?) {
-  val expected = other?.asList()
-  val actual = this?.asList()
-  if (actual != expected)
-    ErrorCollector.collectOrThrow(equalsError(expected, actual))
-}
-
-infix fun CharArray?.shouldBe(other: CharArray?) {
-  val expected = other?.asList()
-  val actual = this?.asList()
-  if (actual != expected)
-    ErrorCollector.collectOrThrow(equalsError(expected, actual))
-}
-
-infix fun <T> Array<T>?.shouldBe(other: Array<T>?) {
-  val expected = other?.asList()
-  val actual = this?.asList()
-  if (actual != expected)
-    ErrorCollector.collectOrThrow(equalsError(expected, actual))
-}
 
 private fun equalsError(expected: Any?, actual: Any?): Throwable {
   val expectedRepr = stringRepr(expected)

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/matchers/collections/ArrayEqualsTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/matchers/collections/ArrayEqualsTest.kt
@@ -6,27 +6,27 @@ import io.kotlintest.shouldBe
 class ArrayEqualsTest : StringSpec() {
   init {
     "shouldBe should support int arrays" {
-      val array = intArrayOf(1, 2, 3)
+      val array: Any = intArrayOf(1, 2, 3)
       array shouldBe intArrayOf(1, 2, 3)
     }
     "shouldBe should support long arrays" {
-      val array = longArrayOf(1L, 2L, 3L)
+      val array: Any = longArrayOf(1L, 2L, 3L)
       array shouldBe longArrayOf(1L, 2L, 3L)
     }
     "shouldBe should support double arrays" {
-      val array = doubleArrayOf(1.0, 2.0, 3.0)
+      val array: Any = doubleArrayOf(1.0, 2.0, 3.0)
       array shouldBe doubleArrayOf(1.0, 2.0, 3.0)
     }
     "shouldBe should support boolean arrays" {
-      val array = booleanArrayOf(true, false)
+      val array: Any = booleanArrayOf(true, false)
       array shouldBe booleanArrayOf(true, false)
     }
     "shouldBe should support generic arrays" {
-      val array = arrayOf("hello", "welcome")
+      val array: Any = arrayOf("hello", "welcome")
       array shouldBe arrayOf("hello", "welcome")
     }
     "shouldBe should support nullable boolean arrays" {
-      val someBooleans = arrayOf(false, true, false) as Array<Boolean?>
+      val someBooleans: Array<Boolean?> = arrayOf(false, true, false)
       someBooleans shouldBe arrayOf<Boolean?>(false, true, false)
     }
   }


### PR DESCRIPTION
Currently, there are a number of `shouldBe` overloads for specialized types. If you call `shouldBe` on an `Any` that is actually one of these types, the overloads can't be used, and the comparisons fail incorrectly. 

This PR uses runtime inspections rather than the `shouldBe` overloads. This has the additional positive effect of fixing all the other `shouldBe`-equivalent functions like `should be(expected)` and `shouldNotBe`.