### PR TITLE
Add infix support to map matchers

### DIFF
--- a/kotlintest-assertions/src/main/kotlin/io/kotlintest/matchers/maps/matchers.kt
+++ b/kotlintest-assertions/src/main/kotlin/io/kotlintest/matchers/maps/matchers.kt
@@ -18,17 +18,17 @@ fun <K, V> mapcontain(key: K, v: V) = object : Matcher<Map<K, V>> {
 fun <K, V> Map<K, V>.shouldContain(key: K, value: V) = this should mapcontain(key, value)
 fun <K, V> Map<K, V>.shouldNotContain(key: K, value: V) = this shouldNot mapcontain(key, value)
 
-fun <K, V> Map<K, V>.shouldContainExactly(expected: Map<K, V>) = this should containExactly(expected)
-fun <K, V> Map<K, V>.shouldNotContainExactly(expected: Map<K, V>) = this shouldNot containExactly(expected)
+infix fun <K, V> Map<K, V>.shouldContainExactly(expected: Map<K, V>) = this should containExactly(expected)
+infix fun <K, V> Map<K, V>.shouldNotContainExactly(expected: Map<K, V>) = this shouldNot containExactly(expected)
 
-fun <K, V> Map<K, V>.shouldContainAll(expected: Map<K, V>) = this should containAll(expected)
-fun <K, V> Map<K, V>.shouldNotContainAll(expected: Map<K, V>) = this shouldNot containAll(expected)
+infix fun <K, V> Map<K, V>.shouldContainAll(expected: Map<K, V>) = this should containAll(expected)
+infix fun <K, V> Map<K, V>.shouldNotContainAll(expected: Map<K, V>) = this shouldNot containAll(expected)
 
-fun <K, V> Map<K, V>.shouldContainKey(key: K) = this should haveKey(key)
-fun <K, V> Map<K, V>.shouldNotContainKey(key: K) = this shouldNot haveKey(key)
+infix fun <K, V> Map<K, V>.shouldContainKey(key: K) = this should haveKey(key)
+infix fun <K, V> Map<K, V>.shouldNotContainKey(key: K) = this shouldNot haveKey(key)
 
-fun <K, V> Map<K, V>.shouldContainValue(value: V) = this should haveValue(value)
-fun <K, V> Map<K, V>.shouldNotContainValue(value: V) = this shouldNot haveValue(value)
+infix fun <K, V> Map<K, V>.shouldContainValue(value: V) = this should haveValue(value)
+infix fun <K, V> Map<K, V>.shouldNotContainValue(value: V) = this shouldNot haveValue(value)
 
 fun <K, V> Map<K, V>.shouldContainKeys(vararg keys: K) = this should haveKeys(*keys)
 fun <K, V> Map<K, V>.shouldNotContainKeys(vararg keys: K) = this shouldNot haveKeys(*keys)


### PR DESCRIPTION
I ran into this need when I wanted to use `myMap shouldContainKey "version"`