### PR TITLE
Add Boolean matchers documentation and unit tests

### DIFF
--- a/kotlintest-assertions/src/main/kotlin/io/kotlintest/matchers/boolean/BooleanMatchers.kt
+++ b/kotlintest-assertions/src/main/kotlin/io/kotlintest/matchers/boolean/BooleanMatchers.kt
@@ -2,6 +2,35 @@ package io.kotlintest.matchers.boolean
 
 import io.kotlintest.shouldBe
 
+/**
+ * Asserts that this [Boolean] is true
+ *
+ * Verifies that this [Boolean] or boolean expression is true.
+ * Opposite of [Boolean.shouldBeFalse]
+ *
+ * ```
+ * true.shouldBeTrue    // Assertion passes
+ * false.shouldBeTrue   // Assertion fails
+ *
+ * (3 + 3 == 6).shouldBeTrue    // Assertion passes
+ * (3 + 3 == 42).shouldBeTrue   // Assertion fails
+ * ```
+ */
 fun Boolean.shouldBeTrue() = this shouldBe true
 
+
+/**
+ * Asserts that this [Boolean] is false
+ *
+ * Verifies that this [Boolean] or boolean expression is false.
+ * Opposite of [Boolean.shouldBeTrue]
+ *
+ * ```
+ * false.shouldBeFalse  // Assertion passes
+ * true.shouldBeFalse   // Assertion fails
+ *
+ * (3 + 3 == 42).shouldBeFalse  // Assertion passes
+ * (3 + 3 == 6).shouldBeFalse   // Assertion fails
+ * ```
+ */
 fun Boolean.shouldBeFalse() = this shouldBe false

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/matchers/boolean/BooleanMatchersTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/matchers/boolean/BooleanMatchersTest.kt
@@ -1,0 +1,49 @@
+package com.sksamuel.kotlintest.matchers.boolean
+
+import io.kotlintest.matchers.boolean.shouldBeFalse
+import io.kotlintest.matchers.boolean.shouldBeTrue
+import io.kotlintest.shouldBe
+import io.kotlintest.shouldThrow
+import io.kotlintest.specs.FreeSpec
+import org.opentest4j.AssertionFailedError
+
+@Suppress("SimplifyBooleanWithConstants")
+class BooleanMatchersTest : FreeSpec() {
+
+    
+    init {
+        "Boolean shouldBeTrue should not fail for true booleans" {
+            true.shouldBeTrue()
+            (3 + 3 == 6).shouldBeTrue()
+        }
+        
+        "Boolean shouldBeTrue should fail for false booleans" - {
+            val thrownException = shouldThrow<AssertionFailedError> { false.shouldBeTrue() }
+            
+            "Failure exception should expect true" {
+                thrownException.expected.value shouldBe "true"
+            }
+            
+            "Failure exception should have actual false" {
+                thrownException.actual.value shouldBe "false"
+            }
+        }
+        
+        "Boolean shouldBeFalse should not fail for false booleans" {
+            false.shouldBeFalse()
+            (3 + 3 == 42).shouldBeFalse()
+        }
+        
+        "Boolean shouldBeFalse should fail for true booleans" - {
+            val thrownException = shouldThrow<AssertionFailedError> { true.shouldBeFalse() }
+    
+            "Failure exception should expect false" {
+                thrownException.expected.value shouldBe "false"
+            }
+    
+            "Failure exception should have actual true" {
+                thrownException.actual.value shouldBe "true"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Boolean Matchers, although very trivial, are lacking some documentations, and this PR aims to fix that.

Solves https://github.com/kotlintest/kotlintest/issues/424