### PR TITLE
Add arrow-assertion Failure matcher that checks underlying throwable equality

### DIFF
--- a/doc/arrow-matchers.md
+++ b/doc/arrow-matchers.md
@@ -32,7 +32,7 @@ This page lists all current matchers in the KotlinTest arrow matchers extension 
 | `try.shouldBeSuccess()` | Asserts that the try is of type Success |
 | `try.shouldBeSuccess(v)` | Asserts that the try is of type Success with specified value v |
 | `try.shouldBeFailure()` | Asserts that the try is of type Failure |
-| `try.shouldBeFailureWithThrowable<A : Throwable>()` | Asserts that the try is of type Failure with a specified Exception type A |
+| `try.shouldBeFailureOfType<A : Throwable>()` | Asserts that the try is of type Failure with a specified exception type A |
 
 | Validated | |
 | -------- | ---- |

--- a/doc/arrow-matchers.md
+++ b/doc/arrow-matchers.md
@@ -32,6 +32,7 @@ This page lists all current matchers in the KotlinTest arrow matchers extension 
 | `try.shouldBeSuccess()` | Asserts that the try is of type Success |
 | `try.shouldBeSuccess(v)` | Asserts that the try is of type Success with specified value v |
 | `try.shouldBeFailure()` | Asserts that the try is of type Failure |
+| `try.shouldBeFailureWithThrowable<A : Throwable>()` | Asserts that the try is of type Failure with a specified Exception type A |
 
 | Validated | |
 | -------- | ---- |

--- a/kotlintest-assertions-arrow/src/main/kotlin/io/kotlintest/assertions/arrow/try/matchers.kt
+++ b/kotlintest-assertions-arrow/src/main/kotlin/io/kotlintest/assertions/arrow/try/matchers.kt
@@ -39,9 +39,9 @@ fun beFailure() = object : Matcher<Try<Any>> {
   }
 }
 
-inline fun <reified A : Throwable> Try<Any>.shouldBeFailureWithThrowable() = this should beFailureWithThrowable<A>()
-inline fun <reified A : Throwable> Try<Any>.shouldNotBeFailureWithThrowable() = this shouldNot beFailureWithThrowable<A>()
-inline fun <reified A : Throwable> beFailureWithThrowable() = object : Matcher<Try<Any>> {
+inline fun <reified A : Throwable> Try<Any>.shouldBeFailureOfType() = this should beFailureOfType<A>()
+inline fun <reified A : Throwable> Try<Any>.shouldNotBeFailureOfType() = this shouldNot beFailureOfType<A>()
+inline fun <reified A : Throwable> beFailureOfType() = object : Matcher<Try<Any>> {
   override fun test(value: Try<Any>): Result {
     return when (value) {
       is Try.Success<*> -> Result(false, "Try should be a Failure but was Success(${value.value})", "")

--- a/kotlintest-assertions-arrow/src/main/kotlin/io/kotlintest/assertions/arrow/try/matchers.kt
+++ b/kotlintest-assertions-arrow/src/main/kotlin/io/kotlintest/assertions/arrow/try/matchers.kt
@@ -38,3 +38,19 @@ fun beFailure() = object : Matcher<Try<Any>> {
     }
   }
 }
+
+inline fun <reified A : Throwable> Try<Any>.shouldBeFailureWithThrowable() = this should beFailureWithThrowable<A>()
+inline fun <reified A : Throwable> Try<Any>.shouldNotBeFailureWithThrowable() = this shouldNot beFailureWithThrowable<A>()
+inline fun <reified A : Throwable> beFailureWithThrowable() = object : Matcher<Try<Any>> {
+  override fun test(value: Try<Any>): Result {
+    return when (value) {
+      is Try.Success<*> -> Result(false, "Try should be a Failure but was Success(${value.value})", "")
+      is Try.Failure<*> -> {
+        if (value.exception is A)
+          Result(true, "Try should be a Failure(${A::class})", "Try should not be Failure")
+        else
+          Result(false, "Try should be a Failure(${A::class}), but was Failure(${value.exception::class})", "Try should not be Failure")
+      }
+    }
+  }
+}

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/assertions/arrow/TryMatchersTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/assertions/arrow/TryMatchersTest.kt
@@ -2,11 +2,14 @@ package com.sksamuel.kotlintest.assertions.arrow
 
 import arrow.core.Try
 import io.kotlintest.assertions.arrow.`try`.beFailure
+import io.kotlintest.assertions.arrow.`try`.beFailureWithThrowable
 import io.kotlintest.assertions.arrow.`try`.beSuccess
 import io.kotlintest.should
 import io.kotlintest.shouldBe
+import io.kotlintest.shouldNot
 import io.kotlintest.shouldThrow
 import io.kotlintest.specs.WordSpec
+import java.io.IOException
 
 class TryMatchersTest : WordSpec() {
 
@@ -35,6 +38,21 @@ class TryMatchersTest : WordSpec() {
 
         Try.Failure<Nothing>(RuntimeException()) should beFailure()
       }
+
+      "test that a try is a Failure with a given throwable" {
+        shouldThrow<AssertionError> {
+          Try.Success("foo") should beFailureWithThrowable<RuntimeException>()
+        }.message shouldBe "Try should be a Failure but was Success(foo)"
+
+        shouldThrow<AssertionError> {
+          Try.Failure<Nothing>(RuntimeException()) should beFailureWithThrowable<IOException>()
+        }.message shouldBe "Try should be a Failure(${IOException::class}), but was Failure(${RuntimeException::class})"
+
+        Try.Failure<Nothing>(RuntimeException()) should beFailureWithThrowable<RuntimeException>()
+        Try.Failure<Nothing>(RuntimeException()) should beFailureWithThrowable<Exception>()
+        Try.Failure<Nothing>(Exception()) shouldNot beFailureWithThrowable<java.lang.RuntimeException>()
+      }
     }
   }
 }
+

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/assertions/arrow/TryMatchersTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/assertions/arrow/TryMatchersTest.kt
@@ -2,7 +2,7 @@ package com.sksamuel.kotlintest.assertions.arrow
 
 import arrow.core.Try
 import io.kotlintest.assertions.arrow.`try`.beFailure
-import io.kotlintest.assertions.arrow.`try`.beFailureWithThrowable
+import io.kotlintest.assertions.arrow.`try`.beFailureOfType
 import io.kotlintest.assertions.arrow.`try`.beSuccess
 import io.kotlintest.should
 import io.kotlintest.shouldBe
@@ -41,18 +41,17 @@ class TryMatchersTest : WordSpec() {
 
       "test that a try is a Failure with a given throwable" {
         shouldThrow<AssertionError> {
-          Try.Success("foo") should beFailureWithThrowable<RuntimeException>()
+          Try.Success("foo") should beFailureOfType<RuntimeException>()
         }.message shouldBe "Try should be a Failure but was Success(foo)"
 
         shouldThrow<AssertionError> {
-          Try.Failure<Nothing>(RuntimeException()) should beFailureWithThrowable<IOException>()
+          Try.Failure<Nothing>(RuntimeException()) should beFailureOfType<IOException>()
         }.message shouldBe "Try should be a Failure(${IOException::class}), but was Failure(${RuntimeException::class})"
 
-        Try.Failure<Nothing>(RuntimeException()) should beFailureWithThrowable<RuntimeException>()
-        Try.Failure<Nothing>(RuntimeException()) should beFailureWithThrowable<Exception>()
-        Try.Failure<Nothing>(Exception()) shouldNot beFailureWithThrowable<java.lang.RuntimeException>()
+        Try.Failure<Nothing>(RuntimeException()) should beFailureOfType<RuntimeException>()
+        Try.Failure<Nothing>(RuntimeException()) should beFailureOfType<Exception>()
+        Try.Failure<Nothing>(Exception()) shouldNot beFailureOfType<RuntimeException>()
       }
     }
   }
 }
-


### PR DESCRIPTION
Same as PR (https://github.com/kotlintest/kotlintest/pull/426)
References (https://github.com/kotlintest/kotlintest/issues/422)

-----
Ability to check not just whether a Try returned a Failure, but whether the Failure contained a specific Throwable would be very useful. (https://github.com/kotlintest/kotlintest/issues/422)

Currently to check the underlying exception type, one needs to do something similar to:
```
val failure = Try.Failure(Exception("foo"))
failure should beFailure() // passes
shouldThrow<Exception> {
    failure.getOrElse { fail("Could not get exception") }
}
```
The goal of this PR is to allow the user to be able to do:
```
val failure = Try.Failure(Exception("foo"))
failure should beFailureOfType<Exception>() // Passes test
failure should beFailureOfType<SomeOtherException>() // Does not pass test
```

This was accomplished relatively easily with Kotlins inline function + reified generic types.
