### PR TITLE
BugFix: Double matcher shouldNotBeExactly

### DIFF
--- a/kotlintest-assertions/src/main/kotlin/io/kotlintest/matchers/doubles/matchers.kt
+++ b/kotlintest-assertions/src/main/kotlin/io/kotlintest/matchers/doubles/matchers.kt
@@ -8,7 +8,7 @@ import io.kotlintest.shouldBe
 import io.kotlintest.shouldNotBe
 
 infix fun Double.shouldBeExactly(other: Double) = this shouldBe exactly(other)
-infix fun Double.shouldNotBeExactly(other: Double) = this shouldBe exactly(other)
+infix fun Double.shouldNotBeExactly(other: Double) = this shouldNotBe exactly(other)
 fun Double.shouldBeBetween(a: Double, b: Double, tolerance: Double) = this shouldBe between(a, b, tolerance)
 fun Double.shouldNotBeBetween(a: Double, b: Double, tolerance: Double) = this shouldNotBe between(a, b, tolerance)
 

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/matchers/numerics/DoubleMatchersTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/matchers/numerics/DoubleMatchersTest.kt
@@ -3,11 +3,13 @@ package com.sksamuel.kotlintest.matchers.numerics
 import io.kotlintest.matchers.between
 import io.kotlintest.matchers.doubles.shouldBeNegative
 import io.kotlintest.matchers.doubles.shouldBePositive
+import io.kotlintest.matchers.doubles.shouldNotBeExactly
 import io.kotlintest.matchers.exactly
 import io.kotlintest.matchers.plusOrMinus
-import io.kotlintest.specs.ShouldSpec
 import io.kotlintest.shouldBe
+import io.kotlintest.shouldNotBe
 import io.kotlintest.shouldThrow
+import io.kotlintest.specs.ShouldSpec
 import io.kotlintest.tables.forAll
 import io.kotlintest.tables.forNone
 import io.kotlintest.tables.headers
@@ -42,6 +44,11 @@ class DoubleMatchersTest : ShouldSpec() {
       shouldThrow<AssertionError> {
         1.0 shouldBe exactly(1.1)
       }
+    }
+    
+    should("not match exactly") {
+      1.0 shouldNotBe exactly(1.1)
+      1.0 shouldNotBeExactly 1.1
     }
 
     should("never match NaN == Nan as per the spec") {


### PR DESCRIPTION
The matcher shouldNotBeExactly is currently a copy of Double.shouldBeExactly, but it's a different method, causing a bug.
This commit fixes it and adds a test to make sure it doesn't happen again.

Solves https://github.com/kotlintest/kotlintest/issues/431