### PR TITLE
Moving Double Matchers to the same file; Deprecated DoubleMatchers.kt

### DIFF
--- a/kotlintest-assertions/src/main/kotlin/io/kotlintest/matchers/DoubleMatchers.kt
+++ b/kotlintest-assertions/src/main/kotlin/io/kotlintest/matchers/DoubleMatchers.kt
@@ -1,47 +1,19 @@
 package io.kotlintest.matchers
 
 import io.kotlintest.Matcher
-import io.kotlintest.Result
-import kotlin.math.abs
+import io.kotlintest.matchers.doubles.ToleranceMatcher
+import io.kotlintest.matchers.doubles.between
+import io.kotlintest.matchers.doubles.exactly
+import io.kotlintest.matchers.doubles.plusOrMinus
 
-infix fun Double.plusOrMinus(tolerance: Double): ToleranceMatcher = ToleranceMatcher(this, tolerance)
+@Deprecated("This method was moved to another package, and will be removed in a future update", ReplaceWith("plusOrMinus(tolerance)", "io.kotlintest.matchers.doubles.plusOrMinus"))
+infix fun Double.plusOrMinus(tolerance: Double) = plusOrMinus(tolerance)
 
-fun exactly(d: Double): Matcher<Double> = object : Matcher<Double> {
-  override fun test(value: Double) = Result(value == d, "$value is not equal to expected value $d", "$value should not equal $d")
-}
+@Deprecated("This method was moved to another package, and will be removed in a future update", ReplaceWith("exactly(d)", "io.kotlintest.matchers.doubles.exactly"))
+fun exactly(d: Double) = exactly(d)
 
-fun between(a: Double, b: Double, tolerance: Double): Matcher<Double> = object : Matcher<Double> {
-  override fun test(value: Double): Result {
-    val differenceToMinimum = value - a
-    val differenceToMaximum = b - value
+@Deprecated("This method was moved to another package, and will be removed in a future update", ReplaceWith("between(a, b, tolerance)", "io.kotlintest.matchers.doubles.between"))
+fun between(a: Double, b: Double, tolerance: Double) = between(a, b, tolerance)
 
-    if (differenceToMinimum < 0 && abs(differenceToMinimum) > tolerance) {
-      return Result(false, "$value should be bigger than $a", "$value should not be bigger than $a")
-    }
-
-    if (differenceToMaximum < 0 && abs(differenceToMaximum) > tolerance) {
-      return Result(false, "$value should be smaller than $b", "$value should not be smaller than $b")
-    }
-
-    return Result(true, "$value should be smaller than $b and bigger than $a", "$value should not be smaller and $b and bigger than $a")
-  }
-}
-
-class ToleranceMatcher(private val expected: Double?, private val tolerance: Double) : Matcher<Double?> {
-  override fun test(value: Double?): Result {
-    return if(value == null || expected == null) {
-      Result(value == expected, "$value should be equal to $expected", "$value should not be equal to $expected")
-    } else if (Double.NaN == expected && Double.NaN == value) {
-      println("[WARN] By design, Double.Nan != Double.Nan; see https://stackoverflow.com/questions/8819738/why-does-double-nan-double-nan-return-false/8819776#8819776")
-      Result(false,
-          "By design, Double.Nan != Double.Nan; see https://stackoverflow.com/questions/8819738/why-does-double-nan-double-nan-return-false/8819776#8819776",
-          "By design, Double.Nan != Double.Nan; see https://stackoverflow.com/questions/8819738/why-does-double-nan-double-nan-return-false/8819776#8819776"
-      )
-    } else {
-      if (tolerance == 0.0)
-        println("[WARN] When comparing doubles consider using tolerance, eg: a shouldBe (b plusOrMinus c)")
-      val diff = Math.abs(value - expected)
-      Result(diff <= tolerance, "$value should be equal to $expected", "$value should not be equal to $expected")
-    }
-  }
-}
+@Deprecated("This class was moved to another package, and will be removed in a future update", ReplaceWith("ToleranceMatcher(expected, tolerance)", "io.kotlintest.matchers.doubles.ToleranceMatcher"))
+class ToleranceMatcher(private val expected: Double?, private val tolerance: Double) : Matcher<Double?> by ToleranceMatcher(expected, tolerance)

--- a/kotlintest-assertions/src/main/kotlin/io/kotlintest/matchers/doubles/matchers.kt
+++ b/kotlintest-assertions/src/main/kotlin/io/kotlintest/matchers/doubles/matchers.kt
@@ -2,15 +2,34 @@ package io.kotlintest.matchers.doubles
 
 import io.kotlintest.Matcher
 import io.kotlintest.Result
-import io.kotlintest.matchers.between
-import io.kotlintest.matchers.exactly
 import io.kotlintest.shouldBe
 import io.kotlintest.shouldNotBe
+import kotlin.math.abs
 
 infix fun Double.shouldBeExactly(other: Double) = this shouldBe exactly(other)
 infix fun Double.shouldNotBeExactly(other: Double) = this shouldNotBe exactly(other)
+fun exactly(d: Double): Matcher<Double> = object : Matcher<Double> {
+  override fun test(value: Double) = Result(value == d, "$value is not equal to expected value $d", "$value should not equal $d")
+}
+
 fun Double.shouldBeBetween(a: Double, b: Double, tolerance: Double) = this shouldBe between(a, b, tolerance)
 fun Double.shouldNotBeBetween(a: Double, b: Double, tolerance: Double) = this shouldNotBe between(a, b, tolerance)
+fun between(a: Double, b: Double, tolerance: Double): Matcher<Double> = object : Matcher<Double> {
+  override fun test(value: Double): Result {
+    val differenceToMinimum = value - a
+    val differenceToMaximum = b - value
+    
+    if (differenceToMinimum < 0 && abs(differenceToMinimum) > tolerance) {
+      return Result(false, "$value should be bigger than $a", "$value should not be bigger than $a")
+    }
+    
+    if (differenceToMaximum < 0 && abs(differenceToMaximum) > tolerance) {
+      return Result(false, "$value should be smaller than $b", "$value should not be smaller than $b")
+    }
+    
+    return Result(true, "$value should be smaller than $b and bigger than $a", "$value should not be smaller and $b and bigger than $a")
+  }
+}
 
 infix fun Double.shouldBeLessThan(x: Double) = this shouldBe lt(x)
 infix fun Double.shouldNotBeLessThan(x: Double) = this shouldNotBe lt(x)
@@ -49,4 +68,27 @@ infix fun Double.shouldNotBeGreaterThanOrEqual(x: Double) = this shouldNotBe gte
 fun gte(x: Double) = beGreaterThanOrEqualTo(x)
 fun beGreaterThanOrEqualTo(x: Double) = object : Matcher<Double> {
   override fun test(value: Double) = Result(value >= x, "$value should be >= $x", "$value should not be >= $x")
+}
+
+
+infix fun Double.plusOrMinus(tolerance: Double): ToleranceMatcher = ToleranceMatcher(this, tolerance)
+
+
+class ToleranceMatcher(private val expected: Double?, private val tolerance: Double) : Matcher<Double?> {
+  override fun test(value: Double?): Result {
+    return if(value == null || expected == null) {
+      Result(value == expected, "$value should be equal to $expected", "$value should not be equal to $expected")
+    } else if (Double.NaN == expected && Double.NaN == value) {
+      println("[WARN] By design, Double.Nan != Double.Nan; see https://stackoverflow.com/questions/8819738/why-does-double-nan-double-nan-return-false/8819776#8819776")
+      Result(false,
+             "By design, Double.Nan != Double.Nan; see https://stackoverflow.com/questions/8819738/why-does-double-nan-double-nan-return-false/8819776#8819776",
+             "By design, Double.Nan != Double.Nan; see https://stackoverflow.com/questions/8819738/why-does-double-nan-double-nan-return-false/8819776#8819776"
+      )
+    } else {
+      if (tolerance == 0.0)
+        println("[WARN] When comparing doubles consider using tolerance, eg: a shouldBe (b plusOrMinus c)")
+      val diff = Math.abs(value - expected)
+      Result(diff <= tolerance, "$value should be equal to $expected", "$value should not be equal to $expected")
+    }
+  }
 }

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/matchers/numerics/DoubleMatchersTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/matchers/numerics/DoubleMatchersTest.kt
@@ -1,11 +1,11 @@
 package com.sksamuel.kotlintest.matchers.numerics
 
-import io.kotlintest.matchers.between
+import io.kotlintest.matchers.doubles.between
+import io.kotlintest.matchers.doubles.exactly
+import io.kotlintest.matchers.doubles.plusOrMinus
 import io.kotlintest.matchers.doubles.shouldBeNegative
 import io.kotlintest.matchers.doubles.shouldBePositive
 import io.kotlintest.matchers.doubles.shouldNotBeExactly
-import io.kotlintest.matchers.exactly
-import io.kotlintest.matchers.plusOrMinus
 import io.kotlintest.shouldBe
 import io.kotlintest.shouldNotBe
 import io.kotlintest.shouldThrow


### PR DESCRIPTION
Double matchers are maintained in two different files. This commit moves all the matchers to the same file, refactoring the old matchers (DoubleMatchers.kt) to simply delegate to the correct file. These old matchers were also deprecated. In a future release, it's intended to remove them altogether.

Solves https://github.com/kotlintest/kotlintest/issues/433