### PR TITLE
Fixed message in Double between matcher

### DIFF
--- a/kotlintest-assertions/src/main/kotlin/io/kotlintest/matchers/doubles/matchers.kt
+++ b/kotlintest-assertions/src/main/kotlin/io/kotlintest/matchers/doubles/matchers.kt
@@ -27,7 +27,7 @@ fun between(a: Double, b: Double, tolerance: Double): Matcher<Double> = object :
       return Result(false, "$value should be smaller than $b", "$value should not be smaller than $b")
     }
     
-    return Result(true, "$value should be smaller than $b and bigger than $a", "$value should not be smaller and $b and bigger than $a")
+    return Result(true, "$value should be smaller than $b and bigger than $a", "$value should not be smaller than $b and should not be bigger than $a")
   }
 }
 


### PR DESCRIPTION
The message was pretty bizarre due to a small typo. This commit fixes that message and makes it clearer.

Solves https://github.com/kotlintest/kotlintest/issues/441