### PR TITLE
Remove matchers "shouldNotBePositive" and "shouldNotBeNegative" from …

### DIFF
--- a/doc/matchers.md
+++ b/doc/matchers.md
@@ -91,9 +91,7 @@ For the extension function style, each function has an equivalent negated versio
 | `double.shouldBeGreaterThan(n)` | Asserts that the double is greater than the given value n |
 | `double.shouldBeGreaterThanOrEqual(n)` | Asserts that the double is greater than or equal to the given value n |
 | `double.shouldBePositive()` | Asserts that the double is positive |
-| `double.shouldNotBePositive()` | Asserts that the double is not positive|
 | `double.shouldBeNegative()` | Asserts that the double is negative |
-| `double.shouldNotBeNegative()` | Asserts that the double is not negative |
 
 | Collections ||
 | -------- | ---- |


### PR DESCRIPTION
…the documentation

These matchers do not belong in the documentation because it already states that every extension function matcher has a negated version, so only "shouldBePositive" and "shouldBeNegative" need to be documented