### PR TITLE
Implements tests for Double Matchers

### DIFF
--- a/kotlintest-assertions/src/main/kotlin/io/kotlintest/properties/Gen.kt
+++ b/kotlintest-assertions/src/main/kotlin/io/kotlintest/properties/Gen.kt
@@ -368,7 +368,7 @@ interface Gen<T> {
      * chosen Double.
      */
     fun double(): Gen<Double> = object : Gen<Double> {
-      val literals = listOf(0.0, Double.MIN_VALUE, Double.MAX_VALUE, Double.NEGATIVE_INFINITY, Double.NaN, Double.POSITIVE_INFINITY)
+      val literals = listOf(0.0, 1.0, -1.0, 1e300, Double.MIN_VALUE, Double.MAX_VALUE, Double.NEGATIVE_INFINITY, Double.NaN, Double.POSITIVE_INFINITY)
       override fun constants(): Iterable<Double> = literals
       override fun random(): Sequence<Double> = generateSequence { RANDOM.nextDouble() }
       override fun shrinker(): Shrinker<Double>? = DoubleShrinker

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/matchers/doubles/DoubleMatchersTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/matchers/doubles/DoubleMatchersTest.kt
@@ -1,72 +1,1061 @@
 package com.sksamuel.kotlintest.matchers.doubles
 
-import io.kotlintest.matchers.doubles.*
+import io.kotlintest.matchers.doubles.beGreaterThan
+import io.kotlintest.matchers.doubles.beGreaterThanOrEqualTo
+import io.kotlintest.matchers.doubles.beLessThan
+import io.kotlintest.matchers.doubles.beLessThanOrEqualTo
+import io.kotlintest.matchers.doubles.between
+import io.kotlintest.matchers.doubles.exactly
+import io.kotlintest.matchers.doubles.gt
+import io.kotlintest.matchers.doubles.gte
+import io.kotlintest.matchers.doubles.lt
+import io.kotlintest.matchers.doubles.lte
+import io.kotlintest.matchers.doubles.negative
+import io.kotlintest.matchers.doubles.positive
+import io.kotlintest.matchers.doubles.shouldBeBetween
+import io.kotlintest.matchers.doubles.shouldBeExactly
+import io.kotlintest.matchers.doubles.shouldBeGreaterThan
+import io.kotlintest.matchers.doubles.shouldBeGreaterThanOrEqual
+import io.kotlintest.matchers.doubles.shouldBeLessThan
+import io.kotlintest.matchers.doubles.shouldBeLessThanOrEqual
+import io.kotlintest.matchers.doubles.shouldBeNegative
+import io.kotlintest.matchers.doubles.shouldBePositive
+import io.kotlintest.matchers.doubles.shouldNotBeBetween
+import io.kotlintest.matchers.doubles.shouldNotBeExactly
+import io.kotlintest.matchers.doubles.shouldNotBeGreaterThan
+import io.kotlintest.matchers.doubles.shouldNotBeGreaterThanOrEqual
+import io.kotlintest.matchers.doubles.shouldNotBeLessThan
+import io.kotlintest.matchers.doubles.shouldNotBeLessThanOrEqual
+import io.kotlintest.matchers.doubles.shouldNotBeNegative
+import io.kotlintest.matchers.doubles.shouldNotBePositive
+import io.kotlintest.properties.Gen
+import io.kotlintest.properties.assertAll
+import io.kotlintest.should
+import io.kotlintest.shouldBe
+import io.kotlintest.shouldNot
 import io.kotlintest.shouldNotBe
-import io.kotlintest.specs.ShouldSpec
-import io.kotlintest.tables.*
+import io.kotlintest.shouldThrow
+import io.kotlintest.specs.FreeSpec
+import kotlin.Double.Companion.MAX_VALUE
+import kotlin.Double.Companion.NEGATIVE_INFINITY
+import kotlin.Double.Companion.NaN
+import kotlin.Double.Companion.POSITIVE_INFINITY
+import kotlin.math.absoluteValue
 
-class DoubleMatchersTest : ShouldSpec() {
-    init {
-
-        should("Not be positive") {
-            val acceptedValues = table(
-                    headers("a"),
-                    row(-1.0),
-                    row(-0.00001),
-                    row(-42.0),
-                    row(0.0),
-                    row(Double.NaN),
-                    row(Double.NEGATIVE_INFINITY)
-            )
-
-            forAll(acceptedValues) {
-                it.shouldNotBePositive()
-                it shouldNotBe positive()
+class DoubleMatchersTest : FreeSpec() {
+  
+  private val nonNumericDoubles = listOf(NaN, POSITIVE_INFINITY, NEGATIVE_INFINITY)
+  
+  private val numericDoubles = Gen.double().filterNot { it in nonNumericDoubles }
+  private val nonMaxValueDoubles = numericDoubles.filter { it != MAX_VALUE }
+  
+  private val delta = 0.0001
+  
+  init {
+    "Exactly Matcher" - {
+      
+      "Every numeric Double" - {
+        
+        "Should be exactly" - {
+          
+          "Itself" {
+            assertAll(numericDoubles) {
+              it shouldExactlyMatch it
             }
-
-            val notAcceptedValues = table(
-                    headers("a"),
-                    row(0.1),
-                    row(1.0),
-                    row(Double.MAX_VALUE),
-                    row(Double.MIN_VALUE),
-                    row(Double.POSITIVE_INFINITY)
-            )
-
-            forNone(notAcceptedValues) {
-                it.shouldNotBePositive()
-                it shouldNotBe positive()
-            }
+          }
         }
-
-        should("Not be negative") {
-            val acceptedValues = table(
-                    headers("a"),
-                    row(1.0),
-                    row(Double.MIN_VALUE),
-                    row(Double.MAX_VALUE),
-                    row(0.001),
-                    row(0.0),
-                    row(Double.NaN),
-                    row(Double.POSITIVE_INFINITY)
-            )
-
-            forAll(acceptedValues) {
-                it.shouldNotBeNegative()
-                it shouldNotBe negative()
+        
+        
+        "Should not be exactly" - {
+          
+          "Any number smaller than itself" {
+            assertAll(nonMaxValueDoubles) {
+              it shouldNotMatchExactly it - delta
             }
-
-            val notAcceptedValues = table(
-                    headers("a"),
-                    row(-0.1),
-                    row(-1.0),
-                    row(Double.NEGATIVE_INFINITY)
-            )
-
-            forNone(notAcceptedValues) {
-                it.shouldNotBeNegative()
-                it shouldNotBe negative()
+          }
+          
+          "Any number bigger than itself" {
+            assertAll(nonMaxValueDoubles) {
+              it shouldNotMatchExactly it + delta
             }
+          }
+          
+          "Anything that's not numeric" {
+            assertAll(numericDoubles) {
+              nonNumericDoubles.forEach { nonNumeric ->
+                it shouldNotMatchExactly nonNumeric
+              }
+            }
+          }
         }
+        
+      }
+      
+      "The non-numeric double" - {
+        "NaN" - {
+          
+          "Should not be exactly" - {
+            
+            "Any number" {
+              assertAll(numericDoubles) {
+                NaN shouldNotMatchExactly it
+              }
+            }
+            
+            "NaN" {
+              NaN shouldNotMatchExactly NaN
+            }
+            
+            "The infinities" {
+              NaN shouldNotMatchExactly POSITIVE_INFINITY
+              NaN shouldNotMatchExactly NEGATIVE_INFINITY
+            }
+          }
+        }
+        
+        "Positive Infinity" - {
+          
+          "Should be exactly" - {
+            "Itself" {
+              POSITIVE_INFINITY shouldExactlyMatch POSITIVE_INFINITY
+            }
+          }
+          
+          "Should not be exactly" - {
+            
+            "Any numeric double" {
+              assertAll(numericDoubles) {
+                POSITIVE_INFINITY shouldNotMatchExactly it
+              }
+            }
+            
+            "Any other non-numeric double" {
+              POSITIVE_INFINITY shouldNotMatchExactly NEGATIVE_INFINITY
+              POSITIVE_INFINITY shouldNotMatchExactly NaN
+            }
+          }
+          
+        }
+        
+        "Negative Infinity" - {
+          
+          "Should be exactly" - {
+            "Itself" {
+              NEGATIVE_INFINITY shouldExactlyMatch NEGATIVE_INFINITY
+            }
+          }
+          
+          "Should not be exactly" - {
+            
+            "Any numeric double" {
+              assertAll(numericDoubles) {
+                NEGATIVE_INFINITY shouldNotMatchExactly it
+              }
+            }
+            
+            "Any other non-numeric double" {
+              NEGATIVE_INFINITY shouldNotMatchExactly POSITIVE_INFINITY
+              NEGATIVE_INFINITY shouldNotMatchExactly NaN
+            }
+          }
+        }
+      }
+      
     }
+    
+    "Between matcher" - {
+      
+      "Every numeric double that is not Double.MAX_VALUE" - {
+        
+        "Should match between" - {
+          
+          "When it's equal to the first number of the range" - {
+            
+            "With tolerance" {
+              onDoubleRange { double, _ ->
+                double.shouldMatchBetween(double, double + delta, delta)
+              }
+            }
+            
+            "Without tolerance" {
+              onDoubleRange { double, _ ->
+                double.shouldMatchBetween(double, double + delta, 0.0)
+                
+              }
+            }
+          }
+          
+          "When it's between the first number of the range and the last one" - {
+            
+            "With tolerance" {
+              onDoubleRange { double, plusMinusValue ->
+                double.shouldMatchBetween(double - plusMinusValue, double + plusMinusValue, delta)
+              }
+            }
+            
+            "Without tolerance" {
+              onDoubleRange { double, plusMinusValue ->
+                double.shouldMatchBetween(double - plusMinusValue, double + plusMinusValue, 0.0)
+                
+              }
+            }
+          }
+          
+          "When it's equal to the last number of the range" - {
+            
+            "With tolerance" {
+              onDoubleRange { double, _ ->
+                double.shouldMatchBetween(double - delta, double, delta)
+              }
+            }
+            
+            "Without tolerance" {
+              onDoubleRange { double, _ ->
+                double.shouldMatchBetween(double - delta, double, 0.0)
+              }
+            }
+          }
+        }
+        
+        "Should not match between" - {
+          
+          "When it's smaller than the first number of the range" - {
+            
+            "With tolerance" {
+              onDoubleRange { double, valueToVariate ->
+                double.shouldNotMatchBetween(double + valueToVariate, double + 2 * valueToVariate, delta)
+              }
+            }
+            
+            "Without tolerance" {
+              onDoubleRange { double, valueToVariate ->
+                double.shouldNotMatchBetween(double + valueToVariate, double + 2 * valueToVariate, 0.0)
+              }
+            }
+          }
+          
+          "When it's bigger than the last number of the range" - {
+            
+            "With tolerance" {
+              onDoubleRange { double, valueToVariate ->
+                double.shouldNotMatchBetween(double - 2 * valueToVariate, double - valueToVariate, delta)
+              }
+            }
+            
+            "Without tolerance" {
+              onDoubleRange { double, valueToVariate ->
+                double.shouldNotMatchBetween(double - 2 * valueToVariate, double - valueToVariate, 0.0)
+              }
+            }
+          }
+        }
+        
+        
+      }
+    }
+    
+    "Less than matcher" - {
+      
+      "Every numeric double" - {
+        
+        "Should be less than" - {
+          
+          "Numbers bigger than itself" {
+            onDoubleRange { double, valueToVariate ->
+              double shouldMatchLessThan double + delta
+              double shouldMatchLessThan double + valueToVariate
+            }
+          }
+          
+          "Infinity" {
+            onDoubleRange { double, _ ->
+              double shouldMatchLessThan POSITIVE_INFINITY
+            }
+          }
+        }
+        
+        
+        "Should not be less than" - {
+          
+          "Itself" {
+            onDoubleRange { double, _ ->
+              double shouldNotMatchLessThan double
+            }
+          }
+          
+          "Numbers smaller than itself" {
+            onDoubleRange { double, valueToVariate ->
+              double shouldNotMatchLessThan double - delta
+              double shouldNotMatchLessThan double - valueToVariate
+            }
+          }
+          
+          "Negative Infinity" {
+            onDoubleRange { double, _ ->
+              double shouldNotMatchLessThan double
+            }
+          }
+          
+          "NaN" {
+            onDoubleRange { double, _ ->
+              double shouldNotMatchLessThan NaN
+            }
+          }
+        }
+        
+      }
+      
+      "The non-numeric double" - {
+        
+        "NaN" - {
+          "Should not be less than" - {
+            
+            "Any numeric double" {
+              onDoubleRange { double, _ ->
+                NaN shouldNotMatchLessThan double
+              }
+            }
+            
+            "Any non-numeric double" {
+              nonNumericDoubles.forEach {
+                NaN shouldNotMatchLessThan it
+              }
+            }
+          }
+          
+        }
+        
+        "Positive Infinity" - {
+          "Should not be less than" - {
+            
+            "Any numeric double" {
+              onDoubleRange { double, _ ->
+                POSITIVE_INFINITY shouldNotMatchLessThan double
+              }
+            }
+            
+            "Any non-numeric double" {
+              nonNumericDoubles.forEach {
+                POSITIVE_INFINITY shouldNotMatchLessThan it
+              }
+            }
+          }
+          
+        }
+        
+        "Negative Infinity" - {
+          
+          "Should be less than" - {
+            
+            "Any numeric double" {
+              onDoubleRange { double, _ ->
+                NEGATIVE_INFINITY shouldMatchLessThan double
+              }
+            }
+            
+            "Positive Infinity" {
+              NEGATIVE_INFINITY shouldMatchLessThan POSITIVE_INFINITY
+            }
+          }
+          
+          "Should not be less than" - {
+            
+            "Itself" {
+              NEGATIVE_INFINITY shouldNotMatchLessThan NEGATIVE_INFINITY
+            }
+            
+            "NaN" {
+              NEGATIVE_INFINITY shouldNotMatchLessThan NaN
+            }
+          }
+        }
+      }
+    }
+    
+    "Positive matcher" - {
+      
+      "Zero" - {
+        "Should not be positive" {
+          0.0.shouldNotMatchPositive()
+        }
+      }
+      "Every positive number" - {
+        
+        "Should be positive" {
+          assertAll(numericDoubles.filterNot { it == 0.0 }) {
+            it.absoluteValue.shouldMatchPositive()
+          }
+        }
+      }
+      
+      "Every non-positive number" - {
+        "Should not be positive" {
+          assertAll(numericDoubles) {
+            (-it.absoluteValue).shouldNotMatchPositive()
+          }
+        }
+      }
+      
+      "The non-numeric double" - {
+        "Positive Infinity" - {
+          "Should be positive" {
+            POSITIVE_INFINITY.shouldMatchPositive()
+          }
+        }
+        
+        "Negative Infinity" - {
+          "Should not be positive" {
+            NEGATIVE_INFINITY.shouldNotMatchPositive()
+          }
+        }
+        
+        "NaN" - {
+          "Should not be positive" {
+            NaN.shouldNotMatchPositive()
+          }
+        }
+      }
+    }
+    
+    "Negative matcher" - {
+      
+      "Zero" - {
+        "Should not be negative" {
+          0.0.shouldNotMatchNegative()
+        }
+      }
+      "Every negative number" - {
+        "Should be negative" {
+          assertAll(numericDoubles.filterNot { it == 0.0 }) {
+            (-it.absoluteValue).shouldMatchNegative()
+          }
+        }
+      }
+      
+      "Every non-negative number" - {
+        "Should not be negative" {
+          assertAll(numericDoubles) {
+            it.absoluteValue.shouldNotMatchNegative()
+          }
+        }
+      }
+      
+      "The non-numeric double" - {
+        "Positive Infinity" - {
+          "Should not be negative" {
+            POSITIVE_INFINITY.shouldNotMatchNegative()
+          }
+        }
+        
+        "Negative Infinity" - {
+          "Should be negative" {
+            NEGATIVE_INFINITY.shouldMatchNegative()
+          }
+        }
+        
+        "NaN" - {
+          "Should not be negative" {
+            NaN.shouldNotMatchNegative()
+          }
+        }
+      }
+    }
+    
+    "Less than or equal matcher" - {
+      "Every numeric double" - {
+        "Should be less than or equal" - {
+          
+          "Itself" {
+            onDoubleRange { double, _ ->
+              double shouldMatchLessThanOrEqual double
+            }
+          }
+          
+          "Numbers bigger than itself" {
+            onDoubleRange { double, valueToVariate ->
+              double shouldMatchLessThanOrEqual double + valueToVariate
+              double shouldMatchLessThanOrEqual double + delta
+            }
+          }
+          
+          "Positive Infinity" {
+            onDoubleRange { double, _ ->
+              double shouldMatchLessThanOrEqual POSITIVE_INFINITY
+            }
+          }
+        }
+        
+        "Should not be less than or equal" - {
+          "Any number smaller than itself" {
+            onDoubleRange { double, valueToVariate ->
+              double shouldNotMatchLessThanOrEqual double - valueToVariate
+              double shouldNotMatchLessThanOrEqual double - delta
+            }
+          }
+          
+          "Negative Infinity" {
+            onDoubleRange { double, _ ->
+              double shouldNotMatchLessThanOrEqual NEGATIVE_INFINITY
+            }
+          }
+          
+          "NaN" {
+            onDoubleRange { double, _ ->
+              double shouldNotMatchLessThanOrEqual NaN
+            }
+          }
+        }
+      }
+      
+      "The non-numeric double" - {
+        "NaN" {
+          "Should not be less than or equal" - {
+            "Any numeric double" {
+              onDoubleRange { double, _ ->
+                NaN shouldNotMatchLessThanOrEqual double
+              }
+            }
+            
+            "Positive Infinity" {
+              NaN shouldNotMatchLessThanOrEqual POSITIVE_INFINITY
+            }
+            
+            "Negative Infinity" {
+              NaN shouldNotMatchLessThanOrEqual NEGATIVE_INFINITY
+            }
+            
+            "Itself" {
+              NaN shouldNotMatchLessThanOrEqual NaN
+            }
+          }
+        }
+        
+        "Positive Infinity" - {
+          
+          "Should be less than or equal" - {
+            "Positive Infinity" {
+              POSITIVE_INFINITY shouldMatchLessThanOrEqual POSITIVE_INFINITY
+            }
+          }
+          "Should not be less than or equal" - {
+            "Any numeric double" {
+              onDoubleRange { double, _ ->
+                POSITIVE_INFINITY shouldNotMatchLessThanOrEqual double
+              }
+            }
+            
+            "Negative Infinity" {
+              POSITIVE_INFINITY shouldNotMatchLessThanOrEqual NEGATIVE_INFINITY
+            }
+            
+            "NaN" {
+              POSITIVE_INFINITY shouldNotMatchLessThanOrEqual NaN
+            }
+          }
+        }
+        
+        "Negative Infinity" - {
+          "Should be less than or equal" - {
+            "Any numeric double" {
+              onDoubleRange { double, _ ->
+                NEGATIVE_INFINITY shouldMatchLessThanOrEqual double
+              }
+            }
+            
+            "Positive Infinity" {
+              NEGATIVE_INFINITY shouldMatchLessThanOrEqual POSITIVE_INFINITY
+            }
+            
+            "Itself" {
+              NEGATIVE_INFINITY shouldMatchLessThanOrEqual NEGATIVE_INFINITY
+            }
+          }
+          
+          "Should not be less than or equal" - {
+            "NaN" {
+              NEGATIVE_INFINITY shouldNotMatchLessThanOrEqual NaN
+            }
+          }
+        }
+      }
+    }
+    
+    "Greater than matcher" - {
+      "Every numeric double" - {
+        "Should be greater than" - {
+          
+          "Numbers smaller than itself" {
+            onDoubleRange { double, valueToVariate ->
+              double shouldMatchGreaterThan double - valueToVariate
+              double shouldMatchGreaterThan double - delta
+            }
+          }
+          
+          "Negative infinity" {
+            onDoubleRange { double, _ ->
+              double shouldMatchGreaterThan NEGATIVE_INFINITY
+            }
+          }
+        }
+        
+        "Should not be greater than" - {
+          
+          "Itself" {
+            onDoubleRange { double, _ ->
+              double shouldNotMatchGreaterThan double
+            }
+          }
+          
+          "Numbers greater than itself" {
+            onDoubleRange { double, valueToVariate ->
+              double shouldNotMatchGreaterThan double + valueToVariate
+              double shouldNotMatchGreaterThan double + delta
+            }
+          }
+          
+          "NaN" {
+            onDoubleRange { double, _ ->
+              double shouldNotMatchGreaterThan NaN
+            }
+          }
+          
+          "Positive Infinity" {
+            onDoubleRange { double, _ ->
+              double shouldNotMatchGreaterThan POSITIVE_INFINITY
+            }
+          }
+        }
+      }
+      
+      "The non-numeric double" - {
+        "NaN" - {
+          "Should not be greater than" - {
+            
+            "Itself" {
+              NaN shouldNotMatchGreaterThan NaN
+            }
+            
+            "Any numeric double" {
+              assertAll(numericDoubles) {
+                NaN shouldNotMatchGreaterThan it
+              }
+            }
+            
+            "Positive Infinity" {
+              NaN shouldNotMatchGreaterThan POSITIVE_INFINITY
+            }
+            
+            "Negative Infinity" {
+              NaN shouldNotMatchGreaterThan NEGATIVE_INFINITY
+            }
+          }
+        }
+      }
+    }
+    
+    "Greater than or equal matcher" - {
+      "Every numeric double" - {
+        "Should be greater than or equal to" - {
+          
+          "Itself" {
+            onDoubleRange { double, _ ->
+              double shouldMatchGreaterThanOrEqual double
+            }
+          }
+          
+          "Numbers smaller than itself" {
+            onDoubleRange { double, valueToVariate ->
+              double shouldMatchGreaterThanOrEqual double - valueToVariate
+              double shouldMatchGreaterThanOrEqual double - delta
+            }
+          }
+          
+          "Negative Infinity" {
+            onDoubleRange { double, _ ->
+              double shouldMatchGreaterThanOrEqual NEGATIVE_INFINITY
+            }
+          }
+        }
+        
+        "Should not be greater than or equal to" - {
+          "Numbers bigger than itself" {
+            onDoubleRange { double, valueToVariate ->
+              double shouldNotMatchGreaterThanOrEqual double + valueToVariate
+              double shouldNotMatchGreaterThanOrEqual double + delta
+            }
+          }
+          
+          "Positive Infinity" {
+            onDoubleRange { double, _ ->
+              double shouldNotMatchGreaterThanOrEqual POSITIVE_INFINITY
+            }
+          }
+          
+          "NaN" {
+            onDoubleRange { double, _ ->
+              double shouldNotMatchGreaterThanOrEqual NaN
+            }
+          }
+        }
+        
+      }
+      
+      "The non-numeric double" - {
+        "NaN" - {
+          "Should not be greater than or equal to" - {
+            "Itself" {
+              NaN shouldNotMatchGreaterThanOrEqual NaN
+            }
+            
+            "Any numeric double" {
+              assertAll(numericDoubles) {
+                NaN shouldNotMatchGreaterThanOrEqual it
+              }
+            }
+            
+            "Positive Infinity" {
+              NaN shouldNotMatchGreaterThanOrEqual POSITIVE_INFINITY
+            }
+            
+            "Negative Infinity" {
+              NaN shouldNotMatchGreaterThanOrEqual NEGATIVE_INFINITY
+            }
+          }
+        }
+        
+        "Positive Infinity" - {
+          "Should be greater than or equal to" - {
+            "Itself" {
+              POSITIVE_INFINITY shouldMatchGreaterThanOrEqual POSITIVE_INFINITY
+            }
+            
+            "Negative Infinity" {
+              POSITIVE_INFINITY shouldMatchGreaterThanOrEqual NEGATIVE_INFINITY
+            }
+            
+            "Any numeric double" {
+              assertAll(numericDoubles) {
+                POSITIVE_INFINITY shouldMatchGreaterThanOrEqual it
+              }
+            }
+          }
+          
+          "Should not be greater than or equal to" - {
+            "NaN" {
+              POSITIVE_INFINITY shouldNotMatchGreaterThanOrEqual NaN
+            }
+          }
+        }
+        
+        "Negative Infinity" - {
+          "Should be greater than or equal to" - {
+            "Itself" {
+              NEGATIVE_INFINITY shouldMatchGreaterThanOrEqual NEGATIVE_INFINITY
+            }
+          }
+          
+          "Should not be greater than or equal to" - {
+            "Any numeric double" {
+              assertAll(numericDoubles) {
+                NEGATIVE_INFINITY shouldNotMatchGreaterThanOrEqual it
+              }
+            }
+            
+            "Positive Infinity" {
+              NEGATIVE_INFINITY shouldNotMatchGreaterThanOrEqual POSITIVE_INFINITY
+            }
+            
+            "NaN" {
+              NEGATIVE_INFINITY shouldNotMatchGreaterThanOrEqual NaN
+            }
+          }
+        }
+      }
+    }
+    
+    
+  }
+  
+  private fun shouldThrowAssertionError(message: String, vararg expression: () -> Any?) {
+    expression.forEach {
+      val exception = shouldThrow<AssertionError>(it)
+      exception.message shouldBe message
+    }
+  }
+  
+  private infix fun Double.shouldExactlyMatch(other: Double) {
+    this shouldBeExactly other
+    this shouldBe exactly(other)
+    this shouldThrowExceptionOnNotExactly other
+  }
+  
+  private infix fun Double.shouldThrowExceptionOnNotExactly(other: Double) {
+    shouldThrowAssertionError("$this should not equal $other",
+                              { this shouldNotBeExactly other },
+                              { this shouldNotBe exactly(other) }
+    )
+  }
+  
+  private infix fun Double.shouldNotMatchExactly(other: Double) {
+    this shouldNotBe exactly(other)
+    this shouldNotBeExactly other
+    this shouldThrowExceptionOnExactly other
+  }
+  
+  private infix fun Double.shouldThrowExceptionOnExactly(other: Double) {
+    shouldThrowAssertionError("$this is not equal to expected value $other",
+                              { this shouldBeExactly other },
+                              { this shouldBe exactly(other) }
+    )
+  }
+  
+  private fun Double.shouldMatchBetween(a: Double, b: Double, tolerance: Double) {
+    this.shouldBeBetween(a, b, tolerance)
+    this shouldBe between(a, b, tolerance)
+    
+    this.shouldThrowExceptionOnNotBetween(a, b, tolerance)
+  }
+  
+  private fun Double.shouldNotMatchBetween(a: Double, b: Double, tolerance: Double) {
+    this.shouldNotBeBetween(a, b, tolerance)
+    this shouldNotBe between(a, b, tolerance)
+    
+    this.shouldThrowExceptionOnBetween(a, b, tolerance)
+  }
+  
+  fun Double.shouldThrowExceptionOnBetween(a: Double, b: Double, tolerance: Double) {
+    when {
+      this < a -> this.shouldThrowMinimumExceptionOnBetween(a, b, tolerance)
+      this > b -> this.shouldThrowMaximumExceptionOnBetween(a, b, tolerance)
+      else     -> throw IllegalStateException()
+    }
+  }
+  
+  private fun Double.shouldThrowMinimumExceptionOnBetween(a: Double, b: Double, tolerance: Double) {
+    val message = "$this should be bigger than $a"
+    shouldThrowExceptionOnBetween(a, b, tolerance, message)
+  }
+  
+  private fun Double.shouldThrowMaximumExceptionOnBetween(a: Double, b: Double, tolerance: Double) {
+    val message = "$this should be smaller than $b"
+    shouldThrowExceptionOnBetween(a, b, tolerance, message)
+  }
+  
+  
+  private fun Double.shouldThrowExceptionOnBetween(a: Double,
+                                                   b: Double,
+                                                   tolerance: Double,
+                                                   message: String = "$this should be smaller than $b and bigger than $a"
+  ) {
+    shouldThrowAssertionError(message,
+                              { this.shouldBeBetween(a, b, tolerance) },
+                              { this shouldBe between(a, b, tolerance) })
+  }
+  
+  private fun Double.shouldThrowExceptionOnNotBetween(a: Double,
+                                                      b: Double,
+                                                      tolerance: Double,
+                                                      message: String = "$this should not be smaller than $b and should not be bigger than $a"
+  ) {
+    
+    shouldThrowAssertionError(message,
+                              { this.shouldNotBeBetween(a, b, tolerance) },
+                              { this shouldNotBe between(a, b, tolerance) })
+  }
+  
+  private fun onDoubleRange(block: (double: Double, valueToVariate: Double) -> Unit) {
+    (0.1..1.0 step 0.2).forEach { valueToVariate ->
+      assertAll(300, nonMaxValueDoubles) {
+        block(it, valueToVariate)
+      }
+    }
+  }
+  
+  private infix fun ClosedRange<Double>.step(step: Double): Iterable<Double> {
+    val sequence = generateSequence(start) { previous ->
+      if (previous == Double.POSITIVE_INFINITY) return@generateSequence null
+      val next = previous + step
+      if (next > endInclusive) null else next
+    }
+    return sequence.asIterable()
+  }
+  
+  private infix fun Double.shouldMatchLessThan(x: Double) {
+    this shouldBe lt(x)
+    this shouldBeLessThan x
+    this should beLessThan(x)
+    
+    this shouldThrowExceptionOnNotLessThan x
+  }
+  
+  private infix fun Double.shouldThrowExceptionOnNotLessThan(x: Double) {
+    shouldThrowAssertionError("$this should not be < $x",
+                              { this shouldNotBe lt(x) },
+                              { this shouldNotBeLessThan x },
+                              { this shouldNot beLessThan(x) })
+  }
+  
+  private infix fun Double.shouldNotMatchLessThan(x: Double) {
+    this shouldNotBe lt(x)
+    this shouldNotBeLessThan x
+    this shouldNot beLessThan(x)
+    
+    this shouldThrowExceptionOnLessThan x
+  }
+  
+  private infix fun Double.shouldThrowExceptionOnLessThan(x: Double) {
+    shouldThrowAssertionError("$this should be < $x",
+                              { this shouldBe lt(x) },
+                              { this shouldBeLessThan x },
+                              { this should beLessThan(x) }
+    )
+  }
+  
+  private fun Double.shouldMatchPositive() {
+    this.shouldBePositive()
+    this shouldBe positive()
+    
+    this.shouldThrowExceptionOnNotPositive()
+  }
+  
+  private fun Double.shouldThrowExceptionOnNotPositive() {
+    shouldThrowAssertionError("$this should not be > 0.0",
+                              { this shouldNotBe positive() },
+                              { this.shouldNotBePositive() }
+    )
+  }
+  
+  private fun Double.shouldNotMatchPositive() {
+    this.shouldNotBePositive()
+    this shouldNotBe positive()
+    
+    this.shouldThrowExceptionOnPositive()
+  }
+  
+  private fun Double.shouldThrowExceptionOnPositive() {
+    shouldThrowAssertionError("$this should be > 0.0",
+                              { this shouldBe positive() },
+                              { this.shouldBePositive() }
+    )
+  }
+  
+  private fun Double.shouldMatchNegative() {
+    this.shouldBeNegative()
+    this shouldBe negative()
+    
+    this.shouldThrowExceptionOnNotNegative()
+  }
+  
+  private fun Double.shouldThrowExceptionOnNotNegative() {
+    shouldThrowAssertionError("$this should not be < 0.0",
+                              { this shouldNotBe negative() },
+                              { this.shouldNotBeNegative() }
+    )
+  }
+  
+  private fun Double.shouldNotMatchNegative() {
+    this.shouldNotBeNegative()
+    this shouldNotBe negative()
+    
+    this.shouldThrowExceptionOnNegative()
+  }
+  
+  private fun Double.shouldThrowExceptionOnNegative() {
+    shouldThrowAssertionError("$this should be < 0.0",
+                              { this shouldBe negative() },
+                              { this.shouldBeNegative() }
+    )
+  }
+  
+  private infix fun Double.shouldMatchLessThanOrEqual(x: Double) {
+    this should beLessThanOrEqualTo(x)
+    this shouldBe lte(x)
+    this shouldBeLessThanOrEqual x
+    
+    this shouldThrowExceptionOnNotLessThanOrEqual x
+  }
+  
+  private infix fun Double.shouldThrowExceptionOnNotLessThanOrEqual(x: Double) {
+    shouldThrowAssertionError("$this should not be <= $x",
+                              { this shouldNot beLessThanOrEqualTo(x) },
+                              { this shouldNotBe lte(x) },
+                              { this shouldNotBeLessThanOrEqual x }
+    )
+  }
+  
+  private infix fun Double.shouldNotMatchLessThanOrEqual(x: Double) {
+    this shouldNot beLessThanOrEqualTo(x)
+    this shouldNotBe lte(x)
+    this shouldNotBeLessThanOrEqual x
+    
+    this shouldThrowExceptionOnLessThanOrEqual x
+  }
+  
+  private infix fun Double.shouldThrowExceptionOnLessThanOrEqual(x: Double) {
+    shouldThrowAssertionError("$this should be <= $x",
+                              { this should beLessThanOrEqualTo(x) },
+                              { this shouldBe lte(x) },
+                              { this shouldBeLessThanOrEqual x }
+    )
+  }
+  
+  private infix fun Double.shouldMatchGreaterThan(x: Double) {
+    this should beGreaterThan(x)
+    this shouldBe gt(x)
+    this shouldBeGreaterThan x
+    
+    this shouldThrowExceptionOnNotGreaterThan x
+  }
+  
+  private infix fun Double.shouldThrowExceptionOnNotGreaterThan(x: Double) {
+    shouldThrowAssertionError("$this should not be > $x",
+                              { this shouldNot beGreaterThan(x) },
+                              { this shouldNotBeGreaterThan (x) },
+                              { this shouldNotBe gt(x) })
+  }
+  
+  private infix fun Double.shouldNotMatchGreaterThan(x: Double) {
+    this shouldNot beGreaterThan(x)
+    this shouldNotBe gt(x)
+    this shouldNotBeGreaterThan x
+    
+    this shouldThrowExceptionOnGreaterThan (x)
+  }
+  
+  private infix fun Double.shouldThrowExceptionOnGreaterThan(x: Double) {
+    shouldThrowAssertionError("$this should be > $x",
+                              { this should beGreaterThan(x) },
+                              { this shouldBe gt(x) },
+                              { this shouldBeGreaterThan x })
+  }
+  
+  private infix fun Double.shouldMatchGreaterThanOrEqual(x: Double) {
+    this should beGreaterThanOrEqualTo(x)
+    this shouldBe gte(x)
+    this shouldBeGreaterThanOrEqual x
+    
+    this shouldThrowExceptionOnNotGreaterThanOrEqual (x)
+  }
+  
+  private infix fun Double.shouldThrowExceptionOnNotGreaterThanOrEqual(x: Double) {
+    shouldThrowAssertionError("$this should not be >= $x",
+                              { this shouldNot beGreaterThanOrEqualTo(x) },
+                              { this shouldNotBe gte(x) },
+                              { this shouldNotBeGreaterThanOrEqual x })
+  }
+  
+  private infix fun Double.shouldNotMatchGreaterThanOrEqual(x: Double) {
+    this shouldNot beGreaterThanOrEqualTo(x)
+    this shouldNotBe gte(x)
+    this shouldNotBeGreaterThanOrEqual x
+    
+    this shouldThrowExceptionOnGreaterThanOrEqual (x)
+  }
+  
+  private infix fun Double.shouldThrowExceptionOnGreaterThanOrEqual(x: Double) {
+    shouldThrowAssertionError("$this should be >= $x",
+                              { this should beGreaterThanOrEqualTo(x) },
+                              { this shouldBe gte(x) },
+                              { this shouldBeGreaterThanOrEqual x })
+  }
 }

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/matchers/doubles/DoubleMatchersTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/matchers/doubles/DoubleMatchersTest.kt
@@ -180,7 +180,7 @@ class DoubleMatchersTest : FreeSpec() {
             "Without tolerance" {
               assertAll(nonMinNorMaxValueDoubles) {
                 it.shouldMatchBetween(it, it.slightlyGreater(), 0.0)
-  
+                
               }
             }
           }
@@ -778,23 +778,23 @@ class DoubleMatchersTest : FreeSpec() {
   
   
   private fun Double.toleranceValue(): Double {
-    return 5 * ulp
+    return ulp
   }
   
   private fun Double.slightlyGreater(): Double {
-    return this + (10 *ulp)
+    return this + (2 * ulp)
   }
   
   private fun Double.muchGreater(): Double {
-    return this + (100 * ulp)
+    return this + (3 * ulp)
   }
   
   private fun Double.slightlySmaller(): Double {
-    return this - (10 * ulp)
+    return this - (2 * ulp)
   }
   
   private fun Double.muchSmaller(): Double {
-    return this - (100 * ulp)
+    return this - (3 * ulp)
   }
   
   private fun shouldThrowAssertionError(message: String, vararg expression: () -> Any?) {
@@ -863,20 +863,22 @@ class DoubleMatchersTest : FreeSpec() {
   }
   
   
-  private fun Double.shouldThrowExceptionOnBetween(a: Double,
-                                                   b: Double,
-                                                   tolerance: Double,
-                                                   message: String = "$this should be smaller than $b and bigger than $a"
+  private fun Double.shouldThrowExceptionOnBetween(
+    a: Double,
+    b: Double,
+    tolerance: Double,
+    message: String = "$this should be smaller than $b and bigger than $a"
   ) {
     shouldThrowAssertionError(message,
                               { this.shouldBeBetween(a, b, tolerance) },
                               { this shouldBe between(a, b, tolerance) })
   }
   
-  private fun Double.shouldThrowExceptionOnNotBetween(a: Double,
-                                                      b: Double,
-                                                      tolerance: Double,
-                                                      message: String = "$this should not be smaller than $b and should not be bigger than $a"
+  private fun Double.shouldThrowExceptionOnNotBetween(
+    a: Double,
+    b: Double,
+    tolerance: Double,
+    message: String = "$this should not be smaller than $b and should not be bigger than $a"
   ) {
     
     shouldThrowAssertionError(message,

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/matchers/doubles/DoubleMatchersTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/matchers/doubles/DoubleMatchersTest.kt
@@ -172,15 +172,15 @@ class DoubleMatchersTest : FreeSpec() {
           "When it's equal to the first number of the range" - {
             
             "With tolerance" {
-              onDoubleRange { double, _ ->
-                double.shouldMatchBetween(double, double + delta, delta)
+              assertAll(nonMaxValueDoubles) {
+                it.shouldMatchBetween(it, it + delta, delta)
               }
             }
             
             "Without tolerance" {
-              onDoubleRange { double, _ ->
-                double.shouldMatchBetween(double, double + delta, 0.0)
-                
+              assertAll(nonMaxValueDoubles) {
+                it.shouldMatchBetween(it, it + delta, 0.0)
+  
               }
             }
           }
@@ -204,14 +204,14 @@ class DoubleMatchersTest : FreeSpec() {
           "When it's equal to the last number of the range" - {
             
             "With tolerance" {
-              onDoubleRange { double, _ ->
-                double.shouldMatchBetween(double - delta, double, delta)
+              assertAll(nonMaxValueDoubles) {
+                it.shouldMatchBetween(it - delta, it, delta)
               }
             }
             
             "Without tolerance" {
-              onDoubleRange { double, _ ->
-                double.shouldMatchBetween(double - delta, double, 0.0)
+              assertAll(nonMaxValueDoubles) {
+                it.shouldMatchBetween(it - delta, it, 0.0)
               }
             }
           }
@@ -268,8 +268,8 @@ class DoubleMatchersTest : FreeSpec() {
           }
           
           "Infinity" {
-            onDoubleRange { double, _ ->
-              double shouldMatchLessThan POSITIVE_INFINITY
+            assertAll(nonMaxValueDoubles) {
+              it shouldMatchLessThan POSITIVE_INFINITY
             }
           }
         }
@@ -278,8 +278,8 @@ class DoubleMatchersTest : FreeSpec() {
         "Should not be less than" - {
           
           "Itself" {
-            onDoubleRange { double, _ ->
-              double shouldNotMatchLessThan double
+            assertAll(nonMaxValueDoubles) {
+              it shouldNotMatchLessThan it
             }
           }
           
@@ -291,14 +291,14 @@ class DoubleMatchersTest : FreeSpec() {
           }
           
           "Negative Infinity" {
-            onDoubleRange { double, _ ->
-              double shouldNotMatchLessThan double
+            assertAll(nonMaxValueDoubles) {
+              it shouldNotMatchLessThan it
             }
           }
           
           "NaN" {
-            onDoubleRange { double, _ ->
-              double shouldNotMatchLessThan NaN
+            assertAll(nonMaxValueDoubles) {
+              it shouldNotMatchLessThan NaN
             }
           }
         }
@@ -311,8 +311,8 @@ class DoubleMatchersTest : FreeSpec() {
           "Should not be less than" - {
             
             "Any numeric double" {
-              onDoubleRange { double, _ ->
-                NaN shouldNotMatchLessThan double
+              assertAll(nonMaxValueDoubles) {
+                NaN shouldNotMatchLessThan it
               }
             }
             
@@ -329,8 +329,8 @@ class DoubleMatchersTest : FreeSpec() {
           "Should not be less than" - {
             
             "Any numeric double" {
-              onDoubleRange { double, _ ->
-                POSITIVE_INFINITY shouldNotMatchLessThan double
+              assertAll(nonMaxValueDoubles) {
+                POSITIVE_INFINITY shouldNotMatchLessThan it
               }
             }
             
@@ -348,8 +348,8 @@ class DoubleMatchersTest : FreeSpec() {
           "Should be less than" - {
             
             "Any numeric double" {
-              onDoubleRange { double, _ ->
-                NEGATIVE_INFINITY shouldMatchLessThan double
+              assertAll(nonMaxValueDoubles) {
+                NEGATIVE_INFINITY shouldMatchLessThan it
               }
             }
             
@@ -466,8 +466,8 @@ class DoubleMatchersTest : FreeSpec() {
         "Should be less than or equal" - {
           
           "Itself" {
-            onDoubleRange { double, _ ->
-              double shouldMatchLessThanOrEqual double
+            assertAll(nonMaxValueDoubles) {
+              it shouldMatchLessThanOrEqual it
             }
           }
           
@@ -479,8 +479,8 @@ class DoubleMatchersTest : FreeSpec() {
           }
           
           "Positive Infinity" {
-            onDoubleRange { double, _ ->
-              double shouldMatchLessThanOrEqual POSITIVE_INFINITY
+            assertAll(nonMaxValueDoubles) {
+              it shouldMatchLessThanOrEqual POSITIVE_INFINITY
             }
           }
         }
@@ -494,14 +494,14 @@ class DoubleMatchersTest : FreeSpec() {
           }
           
           "Negative Infinity" {
-            onDoubleRange { double, _ ->
-              double shouldNotMatchLessThanOrEqual NEGATIVE_INFINITY
+            assertAll(nonMaxValueDoubles) {
+              it shouldNotMatchLessThanOrEqual NEGATIVE_INFINITY
             }
           }
           
           "NaN" {
-            onDoubleRange { double, _ ->
-              double shouldNotMatchLessThanOrEqual NaN
+            assertAll(nonMaxValueDoubles) {
+              it shouldNotMatchLessThanOrEqual NaN
             }
           }
         }
@@ -511,8 +511,8 @@ class DoubleMatchersTest : FreeSpec() {
         "NaN" {
           "Should not be less than or equal" - {
             "Any numeric double" {
-              onDoubleRange { double, _ ->
-                NaN shouldNotMatchLessThanOrEqual double
+              assertAll(nonMaxValueDoubles) {
+                NaN shouldNotMatchLessThanOrEqual it
               }
             }
             
@@ -539,8 +539,8 @@ class DoubleMatchersTest : FreeSpec() {
           }
           "Should not be less than or equal" - {
             "Any numeric double" {
-              onDoubleRange { double, _ ->
-                POSITIVE_INFINITY shouldNotMatchLessThanOrEqual double
+              assertAll(nonMaxValueDoubles) {
+                POSITIVE_INFINITY shouldNotMatchLessThanOrEqual it
               }
             }
             
@@ -557,8 +557,8 @@ class DoubleMatchersTest : FreeSpec() {
         "Negative Infinity" - {
           "Should be less than or equal" - {
             "Any numeric double" {
-              onDoubleRange { double, _ ->
-                NEGATIVE_INFINITY shouldMatchLessThanOrEqual double
+              assertAll(nonMaxValueDoubles) {
+                NEGATIVE_INFINITY shouldMatchLessThanOrEqual it
               }
             }
             
@@ -592,8 +592,8 @@ class DoubleMatchersTest : FreeSpec() {
           }
           
           "Negative infinity" {
-            onDoubleRange { double, _ ->
-              double shouldMatchGreaterThan NEGATIVE_INFINITY
+            assertAll(nonMaxValueDoubles) {
+              it shouldMatchGreaterThan NEGATIVE_INFINITY
             }
           }
         }
@@ -601,8 +601,8 @@ class DoubleMatchersTest : FreeSpec() {
         "Should not be greater than" - {
           
           "Itself" {
-            onDoubleRange { double, _ ->
-              double shouldNotMatchGreaterThan double
+            assertAll(nonMaxValueDoubles) {
+              it shouldNotMatchGreaterThan it
             }
           }
           
@@ -614,14 +614,14 @@ class DoubleMatchersTest : FreeSpec() {
           }
           
           "NaN" {
-            onDoubleRange { double, _ ->
-              double shouldNotMatchGreaterThan NaN
+            assertAll(nonMaxValueDoubles) {
+              it shouldNotMatchGreaterThan NaN
             }
           }
           
           "Positive Infinity" {
-            onDoubleRange { double, _ ->
-              double shouldNotMatchGreaterThan POSITIVE_INFINITY
+            assertAll(nonMaxValueDoubles) {
+              it shouldNotMatchGreaterThan POSITIVE_INFINITY
             }
           }
         }
@@ -658,8 +658,8 @@ class DoubleMatchersTest : FreeSpec() {
         "Should be greater than or equal to" - {
           
           "Itself" {
-            onDoubleRange { double, _ ->
-              double shouldMatchGreaterThanOrEqual double
+            assertAll(nonMaxValueDoubles) {
+              it shouldMatchGreaterThanOrEqual it
             }
           }
           
@@ -671,8 +671,8 @@ class DoubleMatchersTest : FreeSpec() {
           }
           
           "Negative Infinity" {
-            onDoubleRange { double, _ ->
-              double shouldMatchGreaterThanOrEqual NEGATIVE_INFINITY
+            assertAll(nonMaxValueDoubles) {
+              it shouldMatchGreaterThanOrEqual NEGATIVE_INFINITY
             }
           }
         }
@@ -686,14 +686,14 @@ class DoubleMatchersTest : FreeSpec() {
           }
           
           "Positive Infinity" {
-            onDoubleRange { double, _ ->
-              double shouldNotMatchGreaterThanOrEqual POSITIVE_INFINITY
+            assertAll(nonMaxValueDoubles) {
+              it shouldNotMatchGreaterThanOrEqual POSITIVE_INFINITY
             }
           }
           
           "NaN" {
-            onDoubleRange { double, _ ->
-              double shouldNotMatchGreaterThanOrEqual NaN
+            assertAll(nonMaxValueDoubles) {
+              it shouldNotMatchGreaterThanOrEqual NaN
             }
           }
         }

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/matchers/doubles/DoubleMatchersTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/matchers/doubles/DoubleMatchersTest.kt
@@ -41,8 +41,8 @@ import kotlin.Double.Companion.MIN_VALUE
 import kotlin.Double.Companion.NEGATIVE_INFINITY
 import kotlin.Double.Companion.NaN
 import kotlin.Double.Companion.POSITIVE_INFINITY
-import kotlin.math.abs
 import kotlin.math.absoluteValue
+import kotlin.math.ulp
 
 class DoubleMatchersTest : FreeSpec() {
   
@@ -173,7 +173,7 @@ class DoubleMatchersTest : FreeSpec() {
             
             "With tolerance" {
               assertAll(nonMinNorMaxValueDoubles) {
-                it.shouldMatchBetween(it, it.slightlyGreater(), it.smallDelta())
+                it.shouldMatchBetween(it, it.slightlyGreater(), it.toleranceValue())
               }
             }
             
@@ -189,7 +189,7 @@ class DoubleMatchersTest : FreeSpec() {
             
             "With tolerance" {
               assertAll(nonMinNorMaxValueDoubles) {
-                it.shouldMatchBetween(it.slightlySmaller(), it.slightlyGreater(), it.smallDelta())
+                it.shouldMatchBetween(it.slightlySmaller(), it.slightlyGreater(), it.toleranceValue())
               }
             }
             
@@ -204,7 +204,7 @@ class DoubleMatchersTest : FreeSpec() {
             
             "With tolerance" {
               assertAll(nonMinNorMaxValueDoubles) {
-                it.shouldMatchBetween(it.slightlySmaller(), it, it.smallDelta())
+                it.shouldMatchBetween(it.slightlySmaller(), it, it.toleranceValue())
               }
             }
             
@@ -222,7 +222,7 @@ class DoubleMatchersTest : FreeSpec() {
             
             "With tolerance" {
               assertAll(nonMinNorMaxValueDoubles) {
-                it.shouldNotMatchBetween(it.slightlyGreater(), it.muchGreater(), it.smallDelta())
+                it.shouldNotMatchBetween(it.slightlyGreater(), it.muchGreater(), it.toleranceValue())
               }
             }
             
@@ -237,7 +237,7 @@ class DoubleMatchersTest : FreeSpec() {
             
             "With tolerance" {
               assertAll(nonMinNorMaxValueDoubles) {
-                it.shouldNotMatchBetween(it.muchSmaller(), it.slightlySmaller(), it.smallDelta())
+                it.shouldNotMatchBetween(it.muchSmaller(), it.slightlySmaller(), it.toleranceValue())
               }
             }
             
@@ -776,45 +776,25 @@ class DoubleMatchersTest : FreeSpec() {
     
   }
   
-  private fun Double.smallDelta(): Double {
-    return if (this == 0.0) {
-      0.001
-    } else {
-      abs(this * 0.01)
-    }
+  
+  private fun Double.toleranceValue(): Double {
+    return 5 * ulp
   }
   
   private fun Double.slightlyGreater(): Double {
-    return when {
-        this == 0.0 -> 0.01
-        this == 0.0 -> 0.01
-        this < 0    -> (this + smallDelta()) * 0.99
-        else        -> (this + smallDelta()) * 1.01
-    }
+    return this + (10 *ulp)
   }
   
   private fun Double.muchGreater(): Double {
-    return when {
-        this == 0.0 -> 0.50
-        this < 0    -> (this + smallDelta()) * 0.75
-        else        -> (this + smallDelta()) * 1.25
-    }
+    return this + (100 * ulp)
   }
   
   private fun Double.slightlySmaller(): Double {
-    return when {
-        this == 0.0 -> -0.99
-        this < 0    -> (this - smallDelta()) * 1.01
-        else        -> (this - smallDelta()) * 0.99
-    }
+    return this - (10 * ulp)
   }
   
   private fun Double.muchSmaller(): Double {
-    return when {
-        this == 0.0 -> -0.75
-        this < 0    -> (this - smallDelta()) * 1.25
-        else        -> (this - smallDelta()) * 0.75
-    }
+    return this - (100 * ulp)
   }
   
   private fun shouldThrowAssertionError(message: String, vararg expression: () -> Any?) {

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/properties/PropertyAssertAllTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/properties/PropertyAssertAllTest.kt
@@ -10,9 +10,9 @@ import io.kotlintest.properties.Gen
 import io.kotlintest.properties.assertAll
 import io.kotlintest.properties.forAll
 import io.kotlintest.should
-import io.kotlintest.specs.StringSpec
 import io.kotlintest.shouldBe
 import io.kotlintest.shouldThrow
+import io.kotlintest.specs.StringSpec
 
 class PropertyAssertAllTest : StringSpec({
 
@@ -413,7 +413,7 @@ class PropertyAssertAllTest : StringSpec({
     assertAll { _: Int, _: Double, _: String, _: Long, _: Float, _: Int ->
       attempts++
     }
-    attempts shouldBe 2592
+    attempts shouldBe 3888
   }
 
   "sets" {

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/properties/PropertyForAllTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/properties/PropertyForAllTest.kt
@@ -388,7 +388,7 @@ class PropertyForAllTest : StringSpec() {
         attempts++
         true
       }
-      attempts shouldBe 2592
+      attempts shouldBe 3888
     }
 
     "sets" {

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/properties/shrinking/ShrinkTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/properties/shrinking/ShrinkTest.kt
@@ -3,7 +3,6 @@ package com.sksamuel.kotlintest.properties.shrinking
 import io.kotlintest.matchers.doubles.lt
 import io.kotlintest.matchers.lte
 import io.kotlintest.matchers.numerics.shouldBeLessThan
-import io.kotlintest.matchers.numerics.shouldBeLessThanOrEqual
 import io.kotlintest.matchers.string.shouldHaveLength
 import io.kotlintest.properties.Gen
 import io.kotlintest.properties.assertAll
@@ -63,7 +62,7 @@ class ShrinkTest : StringSpec({
       assertAll(Gen.double()) { a ->
         a shouldBe lt(3.0)
       }
-    }.message shouldBe "Property failed for\nArg 0: 3.0 (shrunk from 1.7976931348623157E308)\nafter 3 attempts\nCaused by: 1.7976931348623157E308 should be < 3.0"
+    }.message shouldBe "Property failed for\nArg 0: 3.0 (shrunk from 1.0E300)\nafter 4 attempts\nCaused by: 1.0E300 should be < 3.0"
   }
 
   "should shrink Gen.choose" {


### PR DESCRIPTION
Given the necessity to continually improve the code, having unit tests guarantees that nothing will break when a change is made. This commit focuses on all Double Matchers, refactoring their tests to cover a lot more scenarios and corner cases.

One problem that this commit introduces is that there are way too many lines for a single class. This exposes a code smell on the matchers.kt file, in which ALL the double matchers are placed. This is bad, as each responsibility should be refactored to it's own class. This correction is possible when issue #450 is solved.

Solves https://github.com/kotlintest/kotlintest/issues/430