### PR TITLE
Fixes CI #457

### DIFF
--- a/kotlintest-runner/kotlintest-runner-junit5/src/main/kotlin/io/kotlintest/runner/junit5/JUnitTestRunnerListener.kt
+++ b/kotlintest-runner/kotlintest-runner-junit5/src/main/kotlin/io/kotlintest/runner/junit5/JUnitTestRunnerListener.kt
@@ -149,7 +149,7 @@ class JUnitTestRunnerListener(private val listener: EngineExecutionListener,
         .sortedBy { it.first.depth() }
         .reversed()
         .forEach {
-          val descriptor = descriptors[it.first] ?: descriptors.getOrPut(description) { createTestCaseDescriptor(description, it.second) }
+          val descriptor = descriptors.getOrPut(it.first) { createTestCaseDescriptor(it.first, it.second) }
           // find an error by priority
           val result = findResultFor(it.first)
           if (result == null) {


### PR DESCRIPTION
For some odd reason, the pull request #449 introduces a bug in execution via `./gradlew test`. This small bug will happen for any project, and not only KotlinTest. The gradlew test executor seems to get stuck when trying to resolve the source, and won't execute tests correctly, leading to a permanent freeze.

This commit reverts this problem, but issue #448 will be reopened, as it's not completely fixed for now. The canonical name change won't be reverted, as it didn't cause the bug.

Looking at some other projects, such as Spek, the executor doesn't add a source to the TestDescriptor (see [this line in Spek's TestDescriptor](https://github.com/spekframework/spek/blob/31cad369dbb410a35f686100dea0488a36d505ef/spek-runner/junit5/src/main/kotlin/org/spekframework/spek2/junit/SpekTestDescriptor.kt#L43). I'd assume the problem is similar to this one, and they weren't able to add the source there.

A issue should be opened to Gradle, but I couldn't pinpoint the root cause of this issue, and this will be left as a TODO.

This commit also finds a bug introduced by #447, that makes FailuresTest to fail. This will be fixed in a further commit.

Part of #457