### PR TITLE
Improves Failures implementation

### DIFF
--- a/kotlintest-assertions/src/main/kotlin/io/kotlintest/Failures.kt
+++ b/kotlintest-assertions/src/main/kotlin/io/kotlintest/Failures.kt
@@ -5,28 +5,31 @@ object Failures {
   /**
    * Whether KotlinTest-related frames will be removed from the stack traces of thrown [AssertionError]s.
    *
-   * This defaults to `true`. You can change it at runtime, or set it with the system property
-   * `kotlintest.failures.stacktrace.clean`.
+   * This defaults to `true`. You can change it by setting the system property `kotlintest.failures.stacktrace.clean`.
    *
-   * e.g.
+   * E.g.:
    *
    * ```
    * -Dkotlintest.failures.stacktrace.clean=false
    * ```
    */
-  val shouldRemoveKotlintestElementsFromStacktrace: Boolean = readSystemProperty()
+  val shouldRemoveKotlintestElementsFromStacktrace by lazy { readSystemProperty() }
+  
+  private fun readSystemProperty(): Boolean {
+    return System.getProperty("kotlintest.failures.stacktrace.clean")?.toBoolean() ?: true
+  }
 
   /**
    * Creates an [AssertionError] with the given [message] and [cause]
    *
-   * If [shouldRemoveKotlintestElementsFromStacktrace] is `true`, [removeKotlintestElementsFromStacktrace] will be
-   * called on the returned error.
+   * If [shouldRemoveKotlintestElementsFromStacktrace] is `true`, the stacktrace will be reduced to the user-code
+   * StackTrace only.
    */
   fun failure(message: String, cause: Throwable? = null): AssertionError = AssertionError(message).apply {
     if (shouldRemoveKotlintestElementsFromStacktrace) {
       removeKotlintestElementsFromStacktrace(this)
     }
-    this.initCause(cause)
+    initCause(cause)
   }
 
   /**
@@ -35,16 +38,48 @@ object Failures {
    * If no KotlinTest-related elements are present in the stack trace, it is unchanged.
    */
   fun removeKotlintestElementsFromStacktrace(throwable: Throwable) {
-    val stackTrace = throwable.stackTrace
-    // we are looking for the first stack trace element that is not an internal kotlintest class.
-    throwable.stackTrace = stackTrace.dropWhile {
-      it.className.startsWith("io.kotlintest") ||
-          it.className.startsWith("sun.reflect") ||
-          it.className.startsWith("java.")
-    }.toTypedArray()
+    throwable.stackTrace = UserStackTraceConverter.getUserStacktrace(throwable.stackTrace)
   }
+  
+}
 
-  private fun readSystemProperty(): Boolean {
-    return System.getProperty("kotlintest.failures.stacktrace.clean")?.toBoolean() ?: true
+private object UserStackTraceConverter {
+  
+  fun getUserStacktrace(kotlintestStacktraces: Array<StackTraceElement>): Array<StackTraceElement> {
+    return kotlintestStacktraces.dropUntilUserClass()
   }
+  
+  /**
+   * Drops stacktraces until it finds a Kotlintest Stacktrace then drops stacktraces until it finds a non-Kotlintest stacktrace
+   *
+   * Sometimes, it's possible for the Stacktrace to contain classes that are not from Kotlintest,
+   * such as classes from sun.reflect or anything from Java. After clearing these classes, we'll be at Kotlintest
+   * stacktrace, which will contain exceptions from the Runners and some other classes
+   * After everything from Kotlintest we'll finally be at user classes, at which point the stacktrace is clean and is
+   * returned.
+   */
+  private fun Array<StackTraceElement>.dropUntilUserClass(): Array<StackTraceElement> {
+    return toList().dropUntilFirstKotlintestClass().dropUntilFirstNonKotlintestClass().toTypedArray()
+  }
+  
+  private fun List<StackTraceElement>.dropUntilFirstKotlintestClass(): List<StackTraceElement> {
+    return dropWhile {
+      it.isNotKotlintestClass()
+    }
+  }
+  
+  private fun List<StackTraceElement>.dropUntilFirstNonKotlintestClass(): List<StackTraceElement> {
+    return dropWhile {
+      it.isKotlintestClass()
+    }
+  }
+  
+  private fun StackTraceElement.isKotlintestClass(): Boolean {
+    return className.startsWith("io.kotlintest")
+  }
+  
+  private fun StackTraceElement.isNotKotlintestClass(): Boolean {
+    return !isKotlintestClass()
+  }
+  
 }


### PR DESCRIPTION
As it was, the Failures class would fail to filter classes that are neither from `sun.reflect.*` nor from `java.*`. This commit aims to create a generic implementation that correctly filters stacktraces.

The implemented behavior observes a pattern to clean the stacktrace:

- There may be elements that are not from Kotlintest and are not from User Classes, such as Reflection elements or Java elements (but may be others). These elements are removed.
- Then the code tries to find elements that are indeed from Kotlintest, such as runners and other internals
- After this, it's expected for user classes to be in the stacktrace, so the algorithm stops and returns the stacktrace

By observation of the FailuresTest class, one may believe that only classes from `io.kotlintest` and `sun.reflect` would be in the way of user classes, but that's not the case, and this commit fixes it.

Very related to [this commit](https://github.com/kotlintest/kotlintest/commit/2a2cf22cc6ded49e616f72fc7018c45027a2d719)