### PR TITLE
Add asserts that the either is of type Left with a specified type A 

### DIFF
--- a/doc/arrow-matchers.md
+++ b/doc/arrow-matchers.md
@@ -15,6 +15,7 @@ This page lists all current matchers in the KotlinTest arrow matchers extension 
 | `either.shouldBeRight(v)` | Asserts that the either is of type Right with specified value v |
 | `either.shouldBeLeft()` | Asserts that the either is of type Left |
 | `either.shouldBeLeft(v)` | Asserts that the either is of type Left with specific value v |
+| `either.shouldBeLeftOfType<A>()` | Asserts that the either is of type Left with a specified type A |
 
 | NonEmptyList | |
 | -------- | ---- |

--- a/kotlintest-assertions-arrow/build.gradle
+++ b/kotlintest-assertions-arrow/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
     compile project(":kotlintest-assertions")
-    compile 'io.arrow-kt:arrow-typeclasses:0.8.0'
-    compile 'io.arrow-kt:arrow-data:0.8.0'
+    compile 'io.arrow-kt:arrow-typeclasses:0.8.1'
+    compile 'io.arrow-kt:arrow-data:0.8.1'
 }

--- a/kotlintest-assertions-arrow/src/main/kotlin/io/kotlintest/assertions/arrow/either/matchers.kt
+++ b/kotlintest-assertions-arrow/src/main/kotlin/io/kotlintest/assertions/arrow/either/matchers.kt
@@ -50,3 +50,21 @@ fun <A> beLeft(a: A) = object : Matcher<Either<A, Any>> {
     }
   }
 }
+
+inline fun <reified A> Either<Any, Any>.shouldBeLeftOfType() = this should beLeftOfType<A>()
+inline fun <reified A> Either<Any, Any>.shouldNotBeLeftOfType() = this shouldNot beLeftOfType<A>()
+inline fun <reified A> beLeftOfType() = object : Matcher<Either<Any, Any>> {
+  override fun test(value: Either<Any, Any>): Result {
+    return when (value) {
+      is Either.Right -> {
+        Result(false, "Either should be Left<${A::class.qualifiedName}> but was Right(${value.b})", "")
+      }
+      is Either.Left -> {
+        if (value.a is A)
+          Result(true, "Either should be Left<${A::class.qualifiedName}>", "Either should not be Left")
+        else
+          Result(false, "Either should be Left<${A::class.qualifiedName}> but was Left<${value.a::class.qualifiedName}>", "Either should not be Left")
+      }
+    }
+  }
+}

--- a/kotlintest-runner/kotlintest-runner-jvm/build.gradle
+++ b/kotlintest-runner/kotlintest-runner-jvm/build.gradle
@@ -2,5 +2,5 @@ dependencies {
     compile project(':kotlintest-core')
     compile 'org.reflections:reflections:0.9.11'
     compile 'org.slf4j:slf4j-api:1.7.25'
-    compile 'io.arrow-kt:arrow-core:0.7.1'
+    compile 'io.arrow-kt:arrow-core:0.8.1'
 }

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/assertions/arrow/EitherMatchersTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/assertions/arrow/EitherMatchersTest.kt
@@ -1,11 +1,7 @@
 package com.sksamuel.kotlintest.assertions.arrow
 
 import arrow.core.Either
-import io.kotlintest.assertions.arrow.either.beLeft
-import io.kotlintest.assertions.arrow.either.beRight
-import io.kotlintest.assertions.arrow.either.shouldBeLeft
-import io.kotlintest.assertions.arrow.either.shouldBeRight
-import io.kotlintest.assertions.arrow.either.shouldNotBeRight
+import io.kotlintest.assertions.arrow.either.*
 import io.kotlintest.should
 import io.kotlintest.shouldBe
 import io.kotlintest.shouldThrow
@@ -13,11 +9,17 @@ import io.kotlintest.specs.WordSpec
 
 class EitherMatchersTest : WordSpec() {
 
+  sealed class MyError {
+    object Foo : MyError()
+    object Boo : MyError()
+  }
+
   init {
 
     "Either should beRight()" should {
       "test that the either is of type right" {
         Either.right("boo").shouldBeRight()
+        Either.left("boo").shouldNotBeRight()
       }
     }
 
@@ -32,6 +34,7 @@ class EitherMatchersTest : WordSpec() {
           Either.right("foo") should beRight("boo")
         }.message shouldBe "Either should be Right(boo) but was Right(foo)"
 
+        Either.right("foo").shouldNotBeRight("boo")
         Either.left("foo").shouldNotBeRight("foo")
 
         Either.right("boo") should beRight("boo")
@@ -42,6 +45,7 @@ class EitherMatchersTest : WordSpec() {
     "Either should beLeft()" should {
       "test that the either is of type left" {
         Either.left("boo").shouldBeLeft()
+        Either.right("boo").shouldNotBeLeft()
       }
     }
 
@@ -56,8 +60,27 @@ class EitherMatchersTest : WordSpec() {
           Either.left("foo") should beLeft("boo")
         }.message shouldBe "Either should be Left(boo) but was Left(foo)"
 
+        shouldThrow<AssertionError> {
+          Either.left("foo").shouldNotBeLeft("foo")
+        }.message shouldBe "Either should not be Left(foo)"
+
         Either.left("boo") should beLeft("boo")
         Either.left("boo").shouldBeLeft("boo")
+        Either.right("boo").shouldNotBeLeft("boo")
+      }
+    }
+
+    "Either should beLeftOfType" should {
+      "test that an either is a left have exactly the same type" {
+        shouldThrow<AssertionError> {
+          Either.left(MyError.Boo).shouldBeLeftOfType<MyError.Foo>()
+        }.message shouldBe "Either should be Left<${MyError.Foo::class.qualifiedName}> but was Left<${MyError.Boo::class.qualifiedName}>"
+
+        Either.left(MyError.Foo).shouldBeLeftOfType<MyError.Foo>()
+        Either.left(MyError.Boo).shouldBeLeftOfType<MyError.Boo>()
+
+        Either.left(MyError.Boo).shouldNotBeLeftOfType<MyError.Foo>()
+        Either.right("foo").shouldNotBeLeftOfType<MyError.Foo>()
       }
     }
   }


### PR DESCRIPTION
Current e.x

```kotlin
sealed class MyError() {
  class MyError1(): MyError()
  ...
}

// in test code

either.fold(
  ifLeft = { it should beOfType<MyError1>() },
  ifRight = { fail() }
)

```

The goal of this PR is to allow the user to be able to do:

```
either.shouldBeLeftOfType<MyError1>()
```

like #427