### PR TITLE
Improve `assertSoftly` documentation

### DIFF
--- a/kotlintest-assertions/src/main/kotlin/io/kotlintest/dsl.kt
+++ b/kotlintest-assertions/src/main/kotlin/io/kotlintest/dsl.kt
@@ -1,14 +1,19 @@
 package io.kotlintest
 
 /**
- * Run multiple assertions, collecting any failures into a single exception that is thrown at the end of the
- * block.
+ * Run multiple assertions and throw a single error after all are executed if any fail
+ *
+ * This method will run all the assertions inside [assertions] block, and will collect all failures that may happen.
+ * It then compact all of them in a single throwable and throw it instead, or nothing if no assertion fail.
  *
  * ```
- * verifyAll {
- *   foo shouldBe bar
- *   baz.shouldBeLessThan(qux)
- * }
+ *     // All assertions below are going to be executed, even when one or multiple fail.
+ *     // All the failures are then collected and thrown in one single throwable.
+ *     assertSoftly {
+ *         "foo" shouldBe "bar"
+ *         "foo" shouldBe "foo
+ *         "foo" shouldBe "baz"
+ *     }
  * ```
  */
 inline fun <T> assertSoftly(assertions: () -> T): T {


### PR DESCRIPTION
As it was, the documentation wasn't precise about the use of `assertSoftly`. Its example as for another method, and not `assertSoftly`.

This commit fixes this error in the example, and make some other changes to the documentation, improving understandability.