### PR TITLE
WIP: Removes Kotlin_Version override documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,22 +169,6 @@ dependencies {
     testImplementation("io.kotlintest:kotlintest-runner-junit5:3.1.11")
 }
 ```
-Kotlintest may dirty some configurations, such as `testCompileClasspath`, with kotlin-related old dependencies (`gradle -q dependencyInsight --dependency kotlin-stdlib --configuration testCompileClasspath` to find out more).
-
-You can force the latest versions in this way:
-```groovy
-ext{
-    kotlin_version = '1.3.11'
-}
-dependencies {
-    ...
-    constraints {
-        testImplementation("org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version")
-        testImplementation("org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version")
-        testImplementation("org.jetbrains.kotlin:kotlin-reflect:$kotlin_version")
-    }
-}
-```
 
 #### Maven
 


### PR DESCRIPTION
Pull request #502 updated the README.md documentation to include a workaround to Kotlintest not using Kotlin's latest version. However, this change won't be necessary when Kotlin is updated in version 3.2.0 of Kotlintest.

This commit aims to put this reversion in mind now, so that we don't forget about it later.