### PR TITLE
Implements annotations to execute code in AnnotationSpec

### DIFF
--- a/doc/styles.md
+++ b/doc/styles.md
@@ -170,11 +170,26 @@ class MyTests : ExpectSpec({
 
 ### Annotation Spec
 
-If you are hankering for the halycon days of JUnit then you can use a spec that uses annotations like JUnit 4.
+If you are hankering for the halycon days of JUnit then you can use a spec that uses annotations like JUnit 4/5.
 Just add the `@Test` annotation to any function defined in the spec class.
+
+You can also add annotations to execute something before tests/specs and after tests/specs, similarly to JUnit's
+```
+@BeforeAll / @BeforeClass
+@BeforeEach / @Before
+@AfterAll / @AfterClass
+@AfterEach / @After
+```
+
+If you want to ignore a test, use `@Ignore`
 
 ```kotlin
 class AnnotationSpecExample : AnnotationSpec() {
+
+  @BeforeTest
+  fun beforeTest() {
+    println("Before each test")
+  }
 
   @Test
   fun test1() {

--- a/kotlintest-core/src/main/kotlin/io/kotlintest/specs/AbstractAnnotationSpec.kt
+++ b/kotlintest-core/src/main/kotlin/io/kotlintest/specs/AbstractAnnotationSpec.kt
@@ -1,10 +1,26 @@
 package io.kotlintest.specs
 
 import io.kotlintest.AbstractSpec
+import io.kotlintest.Description
+import io.kotlintest.Spec
 import io.kotlintest.TestCase
+import io.kotlintest.TestCaseConfig
+import io.kotlintest.TestResult
 import io.kotlintest.TestType
+import io.kotlintest.specs.AbstractAnnotationSpec.After
+import io.kotlintest.specs.AbstractAnnotationSpec.AfterAll
+import io.kotlintest.specs.AbstractAnnotationSpec.AfterClass
+import io.kotlintest.specs.AbstractAnnotationSpec.AfterEach
+import io.kotlintest.specs.AbstractAnnotationSpec.Before
+import io.kotlintest.specs.AbstractAnnotationSpec.BeforeAll
+import io.kotlintest.specs.AbstractAnnotationSpec.BeforeClass
+import io.kotlintest.specs.AbstractAnnotationSpec.BeforeEach
+import io.kotlintest.specs.AbstractAnnotationSpec.Ignore
+import kotlin.reflect.KClass
+import kotlin.reflect.KFunction
+import kotlin.reflect.full.memberFunctions
 
-annotation class Test
+typealias Test = AbstractAnnotationSpec.Test
 
 abstract class AbstractAnnotationSpec(body: AbstractAnnotationSpec.() -> Unit = {}) : AbstractSpec() {
 
@@ -12,9 +28,171 @@ abstract class AbstractAnnotationSpec(body: AbstractAnnotationSpec.() -> Unit = 
     body()
   }
 
+  override fun beforeSpec(description: Description, spec: Spec) {
+    super.beforeSpec(description, spec)
+    executeBeforeSpecFunctions()
+  }
+
+  private fun executeBeforeSpecFunctions() = this::class.findBeforeSpecFunctions().forEach { it.call(this) }
+
+  override fun beforeTest(description: Description) {
+    executeBeforeTestFunctions()
+  }
+
+  private fun executeBeforeTestFunctions() = this::class.findBeforeTestFunctions().forEach { it.call(this) }
+
+  override fun afterTest(description: Description, result: TestResult) {
+    executeAfterTestFunctions()
+  }
+
+  private fun executeAfterTestFunctions() = this::class.findAfterTestFunctions().forEach { it.call(this) }
+
+  override fun afterSpec(description: Description, spec: Spec) {
+    executeAfterSpecFunctions()
+  }
+
+  private fun executeAfterSpecFunctions() = this::class.findAfterSpecFunctions().forEach { it.call(this) }
+
   override fun testCases(): List<TestCase> {
-    return javaClass.methods.filter { it.isAnnotationPresent(Test::class.java) }.map {
-      createTestCase(it.name, { it.invoke(this@AbstractAnnotationSpec) }, defaultTestCaseConfig, TestType.Test)
+    return this::class.findTestFunctions().map {
+      if (it.isIgnoredTest()) {
+        it.toIgnoredTestCase()
+      } else {
+        it.toEnabledTestCase()
+      }
     }
   }
+
+  private fun KFunction<*>.toIgnoredTestCase(): TestCase {
+    return createTestCase(defaultTestCaseConfig.copy(enabled = false))
+  }
+
+  private fun KFunction<*>.toEnabledTestCase(): TestCase {
+    return createTestCase(defaultTestCaseConfig)
+  }
+
+  private fun KFunction<*>.createTestCase(config: TestCaseConfig): TestCase {
+    return this.let {
+      createTestCase(it.name, { it.call(this@AbstractAnnotationSpec) }, config, TestType.Test)
+    }
+  }
+
+
+  // All annotations should be kept inside this class, to avoid any usage outside of AnnotationSpec.
+  // One can only use annotations to execute code inside AnnotationSpec.
+
+  /**
+   * Marks a function to be executed before each test
+   *
+   * This can be used in AnnotationSpec to mark a function to be executed before every test by KotlinTest Engine
+   * @see BeforeAll
+   * @see AfterEach
+   */
+  annotation class BeforeEach
+
+  /**
+   * Marks a function to be executed before each test
+   *
+   * This can be used in AnnotationSpec to mark a function to be executed before every test by KotlinTest Engine
+   * @see BeforeClass
+   * @see After
+   */
+  annotation class Before
+
+  /**
+   * Marks a function to be executed before each spec
+   *
+   * This can be used in AnnotationSpec to mark a function to be executed before a spec by KotlinTest Engine.
+   * @see BeforeEach
+   * @see AfterAll
+   */
+  annotation class BeforeAll
+
+  /**
+   * Marks a function to be executed before each spec
+   *
+   * This can be used in AnnotationSpec to mark a function to be executed before a spec by KotlinTest Engine.
+   * @see Before
+   * @see AfterClass
+   */
+  annotation class BeforeClass
+
+  /**
+   * Marks a function to be executed after each test
+   *
+   * This can be used in AnnotationSpec to mark a function to be executed before a test by KotlinTest Engine.
+   * @see AfterAll
+   * @see BeforeEach
+   */
+  annotation class AfterEach
+
+  /**
+   * Marks a function to be executed after each test
+   *
+   * This can be used in AnnotationSpec to mark a function to be executed before a test by KotlinTest Engine.
+   * @see AfterClass
+   * @see Before
+   */
+  annotation class After
+
+
+  /**
+   * Marks a function to be executed after each spec
+   *
+   * This can be used in AnnotationSpec to mark a function to be executed before a spec by KotlinTest Engine.
+   * @see AfterEach
+   * @see BeforeAll
+   */
+  annotation class AfterAll
+
+  /**
+   * Marks a function to be executed after each spec
+   *
+   * This can be used in AnnotationSpec to mark a function to be executed before a spec by KotlinTest Engine.
+   * @see After
+   * @see BeforeClass
+   */
+  annotation class AfterClass
+
+  /**
+   * Marks a function to be executed as a Test
+   *
+   * This can be used in AnnotationSpec to mark a function to be executed as a test by KotlinTest Engine.
+   */
+  annotation class Test
+
+  /**
+   * Marks a Test to be ignored
+   *
+   * This can be used in AnnotationSpec to mark a Test as Ignored.
+   */
+  annotation class Ignore
+
 }
+
+fun KClass<out AbstractAnnotationSpec>.findBeforeTestFunctions() =
+        findFunctionAnnotatedWithAnyOf(BeforeEach::class, Before::class)
+
+fun KClass<out AbstractAnnotationSpec>.findBeforeSpecFunctions() =
+        findFunctionAnnotatedWithAnyOf( BeforeAll::class, BeforeClass::class)
+
+
+fun KClass<out AbstractAnnotationSpec>.findAfterSpecFunctions() =
+        findFunctionAnnotatedWithAnyOf(AfterAll::class, AfterClass::class)
+
+fun KClass<out AbstractAnnotationSpec>.findAfterTestFunctions() =
+        findFunctionAnnotatedWithAnyOf(AfterEach::class, After::class)
+
+
+fun KClass<out AbstractAnnotationSpec>.findTestFunctions() =
+        findFunctionAnnotatedWithAnyOf(AbstractAnnotationSpec.Test::class)
+
+
+fun KFunction<*>.isIgnoredTest() = isFunctionAnnotatedWithAnyOf(Ignore::class)
+
+private fun KClass<out AbstractAnnotationSpec>.findFunctionAnnotatedWithAnyOf(vararg annotation: KClass<*>) =
+        memberFunctions.filter { it.isFunctionAnnotatedWithAnyOf(*annotation) }
+
+
+private fun KFunction<*>.isFunctionAnnotatedWithAnyOf(vararg annotation: KClass<*>) =
+        annotations.any { it.annotationClass in annotation }

--- a/kotlintest-runner/kotlintest-runner-jvm/src/main/kotlin/io/kotlintest/runner/jvm/spec/SpecRunner.kt
+++ b/kotlintest-runner/kotlintest-runner-jvm/src/main/kotlin/io/kotlintest/runner/jvm/spec/SpecRunner.kt
@@ -7,6 +7,7 @@ import io.kotlintest.TestCase
 import io.kotlintest.TestCaseOrder
 import io.kotlintest.extensions.SpecExtension
 import io.kotlintest.extensions.SpecInterceptContext
+import io.kotlintest.extensions.TestListener
 import io.kotlintest.runner.jvm.TestEngineListener
 
 abstract class SpecRunner(val listener: TestEngineListener) {
@@ -30,13 +31,25 @@ abstract class SpecRunner(val listener: TestEngineListener) {
   protected fun interceptSpec(spec: Spec, afterInterception: () -> Unit) {
 
     val listeners = listOf(spec) + spec.listeners() + Project.listeners()
-    listeners.forEach { it.beforeSpec(spec.description(), spec) }
+    executeBeforeSpec(spec, listeners)
 
     val extensions = spec.extensions().filterIsInstance<SpecExtension>() + Project.specExtensions()
     val context = SpecInterceptContext(spec.description(), spec)
     val chain = createSpecInterceptorChain(context, extensions) { afterInterception() }
     chain.invoke()
 
+    executeAfterSpec(spec, listeners)
+  }
+
+  private fun executeBeforeSpec(spec: Spec, listeners: List<TestListener>) {
+    listeners.forEach {
+      it.beforeSpec(spec.description(), spec)
+    }
+  }
+
+  private fun executeAfterSpec(spec: Spec, listeners: List<TestListener>) {
     listeners.reversed().forEach { it.afterSpec(spec.description(), spec) }
   }
+
+
 }

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/specs/annotation/AnnotationSpecTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/specs/annotation/AnnotationSpecTest.kt
@@ -2,9 +2,12 @@ package com.sksamuel.kotlintest.specs.annotation
 
 import io.kotlintest.Description
 import io.kotlintest.Spec
+import io.kotlintest.TestCaseOrder
+import io.kotlintest.TestIsolationMode
+import io.kotlintest.fail
 import io.kotlintest.shouldBe
 import io.kotlintest.specs.AnnotationSpec
-import io.kotlintest.specs.Test
+import java.util.concurrent.atomic.AtomicInteger
 
 class AnnotationSpecTest : AnnotationSpec() {
 
@@ -23,4 +26,86 @@ class AnnotationSpecTest : AnnotationSpec() {
   override fun afterSpec(description: Description, spec: Spec) {
     count shouldBe 2
   }
+}
+
+
+class AnnotationSpecAnnotationsTest : AnnotationSpec() {
+
+  private var counterBeforeSpec = AtomicInteger(0)
+  private var counterBeforeTest = AtomicInteger(0)
+
+  private var counterAfterAll = AtomicInteger(0)
+  private var counterAfterTest = AtomicInteger(0)
+
+
+  // All annotations are repeated sometimes, to validate that all annotations are correctly read by the engine
+
+  @BeforeAll
+  fun beforeSpec1() = counterBeforeSpec.incrementAndGet()
+  @BeforeClass
+  fun beforeSpec2() = counterBeforeSpec.incrementAndGet()
+
+
+  @BeforeEach
+  fun beforeTest1() = counterBeforeTest.incrementAndGet()
+  @Before
+  fun beforeTest2() = counterBeforeTest.incrementAndGet()
+
+  @AfterEach
+  fun afterTest1() = counterAfterTest.incrementAndGet()
+  @After
+  fun afterTest2() = counterAfterTest.incrementAndGet()
+
+  @AfterAll // You're my wonderwall
+  fun afterSpec1() = counterAfterAll.incrementAndGet()
+  @AfterClass
+  fun afterSpec2() = counterAfterAll.incrementAndGet()
+
+
+  // Testing depends on method discovery happening in this order, verifying the assertions in the order tests are declared
+  @Test
+  fun test1() {
+    counterBeforeSpec.get() shouldBe 2 // Both BeforeSpec should be executed once
+    counterBeforeTest.get() shouldBe 2 // Both BeforeTest should be executed once
+
+
+    // No tests finished executing yet, both should be 0
+    counterAfterAll.get() shouldBe 0
+    counterAfterTest.get() shouldBe 0
+  }
+
+  @Test
+  fun test2() {
+    counterBeforeSpec.get() shouldBe 2 // BeforeSpecs should not be executed again
+    counterBeforeTest.get() shouldBe 4 // Before tests should be executed twice (test1 + test2)
+
+    counterAfterAll.get() shouldBe 0  // Not all tests finished yet, it shouldn't have executed
+    counterAfterTest.get() shouldBe 2 // AfterTest should be executed (after test1)
+  }
+
+  @Test
+  fun test3() {
+    counterBeforeSpec.get() shouldBe 2
+    counterBeforeTest.get() shouldBe 6
+
+    counterAfterAll.get() shouldBe 0
+    counterAfterTest.get() shouldBe 4
+  }
+
+  @Ignore
+  @Test
+  fun testIgnore() {
+    fail("This should never execute as the test is marked with @Ignore")
+  }
+
+  // A default after spec verification is necessary, as we cannot test @AfterAll with itself
+  override fun afterSpec(description: Description, spec: Spec) {
+    super.afterSpec(description, spec)
+    counterAfterAll.get() shouldBe 2
+    counterAfterTest.get() shouldBe 6
+  }
+
+  override fun testIsolationMode() = TestIsolationMode.SingleInstance
+
+  override fun testCaseOrder() = TestCaseOrder.Sequential
 }


### PR DESCRIPTION
This commit implements some Annotations and annotation processing to make the transition between JUnit4/5 to Kotlintest easier, giving users some annotations they're familiar with.

This commit also fixes a small bug in test case executor, in which `before` and `after` would be executed even if the test is ignored (bug found in class `AnnotationSpecAnnotationsTest`).

The documentation was updated accordingly.

This should be further reviewed to decide if implementation will be expanded to other specs, or only to `AnnotationSpec`

Fixes https://github.com/kotlintest/kotlintest/issues/513