### PR TITLE
Fixes documentation to the right annotation

### DIFF
--- a/doc/styles.md
+++ b/doc/styles.md
@@ -186,7 +186,7 @@ If you want to ignore a test, use `@Ignore`
 ```kotlin
 class AnnotationSpecExample : AnnotationSpec() {
 
-  @BeforeTest
+  @BeforeEach
   fun beforeTest() {
     println("Before each test")
   }


### PR DESCRIPTION
As of PR #514, a small bug passed through the documentation. We renamed `@BeforeTest` to `@BeforeEach`, but we forgot to change the documentation