### PR TITLE
Add custom exception parsing for reflection call

### DIFF
--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/specs/annotation/AnnotationSpecTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/specs/annotation/AnnotationSpecTest.kt
@@ -3,7 +3,10 @@ package com.sksamuel.kotlintest.specs.annotation
 import io.kotlintest.Description
 import io.kotlintest.IsolationMode
 import io.kotlintest.Spec
+import io.kotlintest.TestCase
 import io.kotlintest.TestCaseOrder
+import io.kotlintest.TestResult
+import io.kotlintest.extensions.TestCaseExtension
 import io.kotlintest.fail
 import io.kotlintest.shouldBe
 import io.kotlintest.specs.AnnotationSpec
@@ -112,4 +115,28 @@ class AnnotationSpecAnnotationsTest : AnnotationSpec() {
   override fun isolationMode() = IsolationMode.SingleInstance
 
   override fun testCaseOrder() = TestCaseOrder.Sequential
+}
+
+class AnnotationSpecFailureTest : AnnotationSpec() {
+  class FooException: Exception()
+
+  private val thrownException = FooException()
+
+  @Test
+  fun foo() {
+    throw thrownException
+  }
+
+  override fun extensions() = listOf(ExceptionCaptureExtension())
+
+  inner class ExceptionCaptureExtension : TestCaseExtension {
+
+    override suspend fun intercept(testCase: TestCase, execute: suspend (TestCase, suspend (TestResult) -> Unit) -> Unit, complete: suspend (TestResult) -> Unit) {
+      execute(testCase) {
+        it.error shouldBe thrownException
+        complete(TestResult.Success)
+      }
+    }
+
+  }
 }


### PR DESCRIPTION
When a test fails from an AnnotationSpec, it was wrapped in an InvocationTargetException, due to it being called via reflection. Because of it, the test failure stacktrace was confusing, as it wouldn't display user's exception directly.

As explained in https://stackoverflow.com/questions/6020719/what-could-cause-java-lang-reflect-invocationtargetexception , this commit attempts to unwrap an exception if it's thrown by a reflection call context, by returning it's cause instead.

Fixes #539