### PR TITLE
Update com.fasterxml.jackson.module:jackson-module-kotlin to 2.9.8

### DIFF
--- a/kotlintest-assertions-json/build.gradle
+++ b/kotlintest-assertions-json/build.gradle
@@ -1,15 +1,1 @@
-buildscript {
-    ext.jackson_version = '2.9.6'
-}
-
-repositories {
-    jcenter()
-}
-
-dependencies {
-    compile project(':kotlintest-assertions')
-    compile "com.fasterxml.jackson.module:jackson-module-kotlin:$jackson_version"
-    compile 'com.jayway.jsonpath:json-path:2.4.0'
-    testCompile project(':kotlintest-core')
-    testCompile project(':kotlintest-runner:kotlintest-runner-junit5')
-}
+new content

--- a/kotlintest-assertions/build.gradle
+++ b/kotlintest-assertions/build.gradle
@@ -1,5 +1,1 @@
-dependencies {
-    compile "org.jetbrains.kotlin:kotlin-reflect"
-    compile 'com.univocity:univocity-parsers:2.7.6'
-    compile group: 'com.github.wumpz', name: 'diffutils', version: '2.2'
-}
+new content


### PR DESCRIPTION
Updates com.fasterxml.jackson.module:jackson-module-kotlin from 2.9.6 to 2.9.8.

If you'd like to skip this version, you can just close this PR.

Have a nice day!