### PR TITLE
Update org.slf4j:slf4j-api to 1.8.0-beta2

### DIFF
--- a/kotlintest-assertions-json/build.gradle
+++ b/kotlintest-assertions-json/build.gradle
@@ -1,1 +1,15 @@
-new content
+updated
+    ext.jackson_version = '2.9.6'
+}
+
+repositories {
+    jcenter()
+}
+
+dependencies {
+    compile project(':kotlintest-assertions')
+    compile "com.fasterxml.jackson.module:jackson-module-kotlin:$jackson_version"
+    compile 'com.jayway.jsonpath:json-path:2.4.0'
+    testCompile project(':kotlintest-core')
+    testCompile project(':kotlintest-runner:kotlintest-runner-junit5')
+}

--- a/kotlintest-assertions-json/build.gradle
+++ b/kotlintest-assertions-json/build.gradle
@@ -1,15 +1,1 @@
-buildscript {
-    ext.jackson_version = '2.9.6'
-}
-
-repositories {
-    jcenter()
-}
-
-dependencies {
-    compile project(':kotlintest-assertions')
-    compile "com.fasterxml.jackson.module:jackson-module-kotlin:$jackson_version"
-    compile 'com.jayway.jsonpath:json-path:2.4.0'
-    testCompile project(':kotlintest-core')
-    testCompile project(':kotlintest-runner:kotlintest-runner-junit5')
-}
+new content

--- a/kotlintest-assertions/build.gradle
+++ b/kotlintest-assertions/build.gradle
@@ -1,1 +1,5 @@
-new content
+updated
+    compile "org.jetbrains.kotlin:kotlin-reflect"
+    compile 'com.univocity:univocity-parsers:2.7.6'
+    compile group: 'com.github.wumpz', name: 'diffutils', version: '2.2'
+}

--- a/kotlintest-assertions/build.gradle
+++ b/kotlintest-assertions/build.gradle
@@ -1,5 +1,1 @@
-dependencies {
-    compile "org.jetbrains.kotlin:kotlin-reflect"
-    compile 'com.univocity:univocity-parsers:2.7.6'
-    compile group: 'com.github.wumpz', name: 'diffutils', version: '2.2'
-}
+new content


### PR DESCRIPTION
Updates org.slf4j:slf4j-api from 1.7.25 to 1.8.0-beta2.

If you'd like to skip this version, you can just close this PR.

Have a nice day!