### PR TITLE
Update javax.xml.bind:jaxb-api to 2.4.0-b180830.0359

### DIFF
--- a/kotlintest-assertions-json/build.gradle
+++ b/kotlintest-assertions-json/build.gradle
@@ -1,1 +1,15 @@
-new content
+updated
+    ext.jackson_version = '2.9.6'
+}
+
+repositories {
+    jcenter()
+}
+
+dependencies {
+    compile project(':kotlintest-assertions')
+    compile "com.fasterxml.jackson.module:jackson-module-kotlin:$jackson_version"
+    compile 'com.jayway.jsonpath:json-path:2.4.0'
+    testCompile project(':kotlintest-core')
+    testCompile project(':kotlintest-runner:kotlintest-runner-junit5')
+}

--- a/kotlintest-assertions-json/build.gradle
+++ b/kotlintest-assertions-json/build.gradle
@@ -1,15 +1,1 @@
-buildscript {
-    ext.jackson_version = '2.9.6'
-}
-
-repositories {
-    jcenter()
-}
-
-dependencies {
-    compile project(':kotlintest-assertions')
-    compile "com.fasterxml.jackson.module:jackson-module-kotlin:$jackson_version"
-    compile 'com.jayway.jsonpath:json-path:2.4.0'
-    testCompile project(':kotlintest-core')
-    testCompile project(':kotlintest-runner:kotlintest-runner-junit5')
-}
+new content

--- a/kotlintest-assertions/build.gradle
+++ b/kotlintest-assertions/build.gradle
@@ -1,1 +1,5 @@
-new content
+updated
+    compile "org.jetbrains.kotlin:kotlin-reflect"
+    compile 'com.univocity:univocity-parsers:2.7.6'
+    compile group: 'com.github.wumpz', name: 'diffutils', version: '2.2'
+}

--- a/kotlintest-assertions/build.gradle
+++ b/kotlintest-assertions/build.gradle
@@ -1,5 +1,1 @@
-dependencies {
-    compile "org.jetbrains.kotlin:kotlin-reflect"
-    compile 'com.univocity:univocity-parsers:2.7.6'
-    compile group: 'com.github.wumpz', name: 'diffutils', version: '2.2'
-}
+new content

--- a/kotlintest-core/build.gradle
+++ b/kotlintest-core/build.gradle
@@ -1,4 +1,4 @@
-dependencies {
+updated
     compile 'org.slf4j:slf4j-api:1.7.25'
     compile "org.jetbrains.kotlin:kotlin-reflect"
     compile 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.1.0'

--- a/kotlintest-extensions/kotlintest-extensions-allure/build.gradle
+++ b/kotlintest-extensions/kotlintest-extensions-allure/build.gradle
@@ -1,4 +1,4 @@
-dependencies {
+updated
     compile project(':kotlintest-core')
     compile project(':kotlintest-assertions')
     compile 'io.qameta.allure:allure-java-commons:2.6.0'


### PR DESCRIPTION
Updates javax.xml.bind:jaxb-api from 2.2.11 to 2.4.0-b180830.0359.

If you'd like to skip this version, you can just close this PR.

Have a nice day!