### PR TITLE
Update org.junit.platform:junit-platform-engine to 1.4.0-M1

### DIFF
--- a/kotlintest-assertions-json/build.gradle
+++ b/kotlintest-assertions-json/build.gradle
@@ -1,1 +1,15 @@
-new content
+updated
+    ext.jackson_version = '2.9.6'
+}
+
+repositories {
+    jcenter()
+}
+
+dependencies {
+    compile project(':kotlintest-assertions')
+    compile "com.fasterxml.jackson.module:jackson-module-kotlin:$jackson_version"
+    compile 'com.jayway.jsonpath:json-path:2.4.0'
+    testCompile project(':kotlintest-core')
+    testCompile project(':kotlintest-runner:kotlintest-runner-junit5')
+}

--- a/kotlintest-assertions-json/build.gradle
+++ b/kotlintest-assertions-json/build.gradle
@@ -1,15 +1,1 @@
-buildscript {
-    ext.jackson_version = '2.9.6'
-}
-
-repositories {
-    jcenter()
-}
-
-dependencies {
-    compile project(':kotlintest-assertions')
-    compile "com.fasterxml.jackson.module:jackson-module-kotlin:$jackson_version"
-    compile 'com.jayway.jsonpath:json-path:2.4.0'
-    testCompile project(':kotlintest-core')
-    testCompile project(':kotlintest-runner:kotlintest-runner-junit5')
-}
+new content

--- a/kotlintest-assertions/build.gradle
+++ b/kotlintest-assertions/build.gradle
@@ -1,1 +1,5 @@
-new content
+updated
+    compile "org.jetbrains.kotlin:kotlin-reflect"
+    compile 'com.univocity:univocity-parsers:2.7.6'
+    compile group: 'com.github.wumpz', name: 'diffutils', version: '2.2'
+}

--- a/kotlintest-assertions/build.gradle
+++ b/kotlintest-assertions/build.gradle
@@ -1,5 +1,1 @@
-dependencies {
-    compile "org.jetbrains.kotlin:kotlin-reflect"
-    compile 'com.univocity:univocity-parsers:2.7.6'
-    compile group: 'com.github.wumpz', name: 'diffutils', version: '2.2'
-}
+new content

--- a/kotlintest-core/build.gradle
+++ b/kotlintest-core/build.gradle
@@ -1,4 +1,4 @@
-dependencies {
+updated
     compile 'org.slf4j:slf4j-api:1.7.25'
     compile "org.jetbrains.kotlin:kotlin-reflect"
     compile 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.1.0'

--- a/kotlintest-extensions/kotlintest-extensions-allure/build.gradle
+++ b/kotlintest-extensions/kotlintest-extensions-allure/build.gradle
@@ -1,4 +1,4 @@
-dependencies {
+updated
     compile project(':kotlintest-core')
     compile project(':kotlintest-assertions')
     compile 'io.qameta.allure:allure-java-commons:2.6.0'

--- a/kotlintest-extensions/kotlintest-extensions-spring/build.gradle
+++ b/kotlintest-extensions/kotlintest-extensions-spring/build.gradle
@@ -1,4 +1,4 @@
-dependencies {
+updated
     compile project(':kotlintest-core')
     compile project(':kotlintest-assertions')
     compile 'org.springframework:spring-test:4.3.14.RELEASE'

--- a/kotlintest-runner/kotlintest-runner-junit4/build.gradle
+++ b/kotlintest-runner/kotlintest-runner-junit4/build.gradle
@@ -1,4 +1,4 @@
-dependencies {
+updated
     compile project(':kotlintest-core')
     compile project(':kotlintest-assertions')
     compile project(':kotlintest-runner:kotlintest-runner-jvm')


### PR DESCRIPTION
Updates org.junit.platform:junit-platform-engine from 1.3.2 to 1.4.0-M1.

If you'd like to skip this version, you can just close this PR.

Have a nice day!